### PR TITLE
tbb GausHitFinder_module

### DIFF
--- a/larreco/HitFinder/CMakeLists.txt
+++ b/larreco/HitFinder/CMakeLists.txt
@@ -22,9 +22,10 @@ art_make(LIB_LIBRARIES
            ${ART_ROOT_IO_TFILESERVICE_SERVICE}
            art_Framework_Services_System_TriggerNamesService_service
            ${MF_MESSAGELOGGER}
-           ROOT::Hist
-           ROOT::MathCore
-           ROOT::Physics
+           ${ROOT_HIST}
+           ${ROOT_MATHCORE}
+           ${ROOT_PHYSICS}
+           ${TBB}
          )
 
 install_headers()

--- a/larreco/HitFinder/CMakeLists.txt
+++ b/larreco/HitFinder/CMakeLists.txt
@@ -22,9 +22,9 @@ art_make(LIB_LIBRARIES
            ${ART_ROOT_IO_TFILESERVICE_SERVICE}
            art_Framework_Services_System_TriggerNamesService_service
            ${MF_MESSAGELOGGER}
-           ${ROOT_HIST}
-           ${ROOT_MATHCORE}
-           ${ROOT_PHYSICS}
+           ROOT::Hist
+           ROOT::MathCore
+           ROOT::Physics
            ${TBB}
          )
 

--- a/larreco/HitFinder/GausHitFinder_module.cc
+++ b/larreco/HitFinder/GausHitFinder_module.cc
@@ -274,7 +274,7 @@ void GausHitFinder::produce(art::Event& evt)
     //for(size_t wireIter = 0; wireIter < wireVecHandle->size(); wireIter++)
     //{
     tbb::parallel_for(static_cast<std::size_t>(0),wireVecHandle->size(),
-		      [&](size_t& wireIter){//size_t wireIter, art::Handle<std::vector<recob::Wire>> wireVecHandle){
+		      [&](size_t& wireIter){
 
 	// ####################################
         // ### Getting this particular wire ###

--- a/larreco/HitFinder/GausHitFinder_module.cc
+++ b/larreco/HitFinder/GausHitFinder_module.cc
@@ -476,7 +476,7 @@ void GausHitFinder::produce(art::Event& evt)
                                                  NDF                               // dof
                                                  );
 
-                    filteredHitVec.push_back(hitcreator.copy());
+                    if (filteredHitCol) filteredHitVec.push_back(hitcreator.copy());
 
                     const recob::Hit hit(hitcreator.move());
 

--- a/larreco/HitFinder/HitFinderTools/CandHitDerivative_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/CandHitDerivative_tool.cc
@@ -134,7 +134,7 @@ void CandHitDerivative::findHitCandidates(const recob::Wire::RegionsOfInterest_t
     // We get this from our waveform algs too...
     Waveform rawDerivativeVec;
     Waveform derivativeVec;
-    
+
     // Recover the actual waveform
     const Waveform& waveform = dataRange.data();
 

--- a/larreco/HitFinder/HitFinderTools/CandHitDerivative_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/CandHitDerivative_tool.cc
@@ -29,9 +29,9 @@ public:
     void configure(const fhicl::ParameterSet& pset) override;
 
     void findHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t&,
-                           size_t,
-                           size_t,
-                           size_t,
+                           const size_t,
+                           const size_t,
+                           const size_t,
                            HitCandidateVec&) const override;
 
     void MergeHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t&,
@@ -42,7 +42,7 @@ private:
     // Internal functions
     void findHitCandidates(Waveform::const_iterator,
                            Waveform::const_iterator,
-                           size_t,
+                           const size_t,
                            int,
                            float,
                            HitCandidateVec&) const;
@@ -125,9 +125,9 @@ void CandHitDerivative::configure(const fhicl::ParameterSet& pset)
 }
 
 void CandHitDerivative::findHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t& dataRange,
-                                          size_t                                               roiStartTick,
-                                          size_t                                               channel,
-                                          size_t                                               eventCount,
+                                          const size_t                                         roiStartTick,
+                                          const size_t                                         channel,
+                                          const size_t                                         eventCount,
                                           HitCandidateVec&                                     hitCandidateVec) const
 {
     // In this case we want to find hit candidates based on the derivative of of the input waveform
@@ -218,7 +218,7 @@ void CandHitDerivative::findHitCandidates(const recob::Wire::RegionsOfInterest_t
 
 void CandHitDerivative::findHitCandidates(Waveform::const_iterator startItr,
                                           Waveform::const_iterator stopItr,
-                                          size_t                   roiStartTick,
+                                          const size_t             roiStartTick,
                                           int                      dTicksThreshold,
                                           float                    dPeakThreshold,
                                           HitCandidateVec&         hitCandidateVec) const

--- a/larreco/HitFinder/HitFinderTools/CandHitMorphological_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/CandHitMorphological_tool.cc
@@ -175,7 +175,7 @@ void CandHitMorphological::findHitCandidates(const recob::Wire::RegionsOfInteres
     // We get this from our waveform algs too...
     Waveform rawDerivativeVec;
     Waveform derivativeVec;
-    
+
     // Recover the actual waveform
     const Waveform& waveform = dataRange.data();
 

--- a/larreco/HitFinder/HitFinderTools/CandHitMorphological_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/CandHitMorphological_tool.cc
@@ -29,9 +29,9 @@ public:
     void configure(const fhicl::ParameterSet& pset) override;
 
     void findHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t&,
-                           size_t,
-                           size_t,
-                           size_t,
+                           const size_t,
+                           const size_t,
+                           const size_t,
                            HitCandidateVec&) const override;
 
     void MergeHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t&,
@@ -44,14 +44,14 @@ private:
     void findHitCandidates(Waveform::const_iterator, Waveform::const_iterator,   //< derivative
                            Waveform::const_iterator, Waveform::const_iterator,   //< erosion
                            Waveform::const_iterator, Waveform::const_iterator,   //< dilation
-                           size_t,
+                           const size_t,
                            float,
                            HitCandidateVec&) const;
 
     //< Fine grain hit finding within candidate peak regions using derivative method
     void findHitCandidates(Waveform::const_iterator,
                            Waveform::const_iterator,
-                           size_t,
+                           const size_t,
                            int,
                            float,
                            HitCandidateVec&) const;
@@ -166,9 +166,9 @@ void CandHitMorphological::configure(const fhicl::ParameterSet& pset)
 }
 
 void CandHitMorphological::findHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t& dataRange,
-                                             size_t                                               roiStartTick,
-                                             size_t                                               channel,
-                                             size_t                                               eventCount,
+                                             const size_t                                         roiStartTick,
+                                             const size_t                                         channel,
+                                             const size_t                                         eventCount,
                                              HitCandidateVec&                                     hitCandidateVec) const
 {
     // In this case we want to find hit candidates based on the derivative of of the input waveform
@@ -296,7 +296,7 @@ void CandHitMorphological::findHitCandidates(const recob::Wire::RegionsOfInteres
 void CandHitMorphological::findHitCandidates(Waveform::const_iterator derivStartItr,    Waveform::const_iterator derivStopItr,
                                              Waveform::const_iterator erosionStartItr,  Waveform::const_iterator erosionStopItr,
                                              Waveform::const_iterator dilationStartItr, Waveform::const_iterator dilationStopItr,
-                                             size_t                   roiStartTick,
+                                             const size_t                   roiStartTick,
                                              float                    dilationThreshold,
                                              HitCandidateVec&         hitCandidateVec) const
 {
@@ -397,7 +397,7 @@ void CandHitMorphological::findHitCandidates(Waveform::const_iterator derivStart
 
 void CandHitMorphological::findHitCandidates(Waveform::const_iterator startItr,
                                              Waveform::const_iterator stopItr,
-                                             size_t                   roiStartTick,
+                                             const size_t             roiStartTick,
                                              int                      dTicksThreshold,
                                              float                    dPeakThreshold,
                                              HitCandidateVec&         hitCandidateVec) const

--- a/larreco/HitFinder/HitFinderTools/CandHitStandard_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/CandHitStandard_tool.cc
@@ -75,7 +75,7 @@ void CandHitStandard::findHitCandidates(const recob::Wire::RegionsOfInterest_t::
 {
     // Recover the actual waveform
     const Waveform& waveform = dataRange.data();
-    
+
     // Recover the plane index for this method
     std::vector<geo::WireID> wids  = fGeometry->ChannelToWire(channel);
     const size_t             plane = wids[0].Plane;
@@ -166,7 +166,7 @@ void CandHitStandard::MergeHitCandidates(const recob::Wire::RegionsOfInterest_t:
 {
     // If no hits then nothing to do here
     if (hitCandidateVec.empty()) return;
-    
+
     // The idea is to group hits that "touch" so they can be part of common fit, those that
     // don't "touch" are fit independently. So here we build the output vector to achieve that
     HitCandidateVec groupedHitVec;

--- a/larreco/HitFinder/HitFinderTools/CandHitStandard_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/CandHitStandard_tool.cc
@@ -23,9 +23,9 @@ public:
     void configure(const fhicl::ParameterSet& pset) override;
 
     void findHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t&,
-                           size_t,
-                           size_t,
-                           size_t,
+                           const size_t,
+                           const size_t,
+                           const size_t,
                            HitCandidateVec&) const override;
 
     void MergeHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t&,
@@ -36,8 +36,8 @@ private:
 
     void findHitCandidates(std::vector<float>::const_iterator,
                            std::vector<float>::const_iterator,
-                           size_t,
-                           size_t,
+                           const size_t,
+                           const size_t,
                            HitCandidateVec&) const;
 
     // Member variables from the fhicl file
@@ -68,9 +68,9 @@ void CandHitStandard::configure(const fhicl::ParameterSet& pset)
 }
 
 void CandHitStandard::findHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t& dataRange,
-                                        size_t                                               roiStartTick,
-                                        size_t                                               channel,
-                                        size_t                                               eventCount,
+                                        const size_t                                         roiStartTick,
+                                        const size_t                                         channel,
+                                        const size_t                                         eventCount,
                                         HitCandidateVec&                                     hitCandidateVec) const
 {
     // Recover the actual waveform
@@ -78,7 +78,7 @@ void CandHitStandard::findHitCandidates(const recob::Wire::RegionsOfInterest_t::
     
     // Recover the plane index for this method
     std::vector<geo::WireID> wids  = fGeometry->ChannelToWire(channel);
-    size_t                   plane = wids[0].Plane;
+    const size_t             plane = wids[0].Plane;
 
     // Use the recursive version to find the candidate hits
     findHitCandidates(waveform.begin(),waveform.end(),roiStartTick,plane,hitCandidateVec);
@@ -88,8 +88,8 @@ void CandHitStandard::findHitCandidates(const recob::Wire::RegionsOfInterest_t::
 
 void CandHitStandard::findHitCandidates(std::vector<float>::const_iterator startItr,
                                         std::vector<float>::const_iterator stopItr,
-                                        size_t                             roiStartTick,
-                                        size_t                             planeIdx,
+                                        const size_t                       roiStartTick,
+                                        const size_t                       planeIdx,
                                         HitCandidateVec&                   hitCandidateVec) const
 {
     // Need a minimum number of ticks to do any work here

--- a/larreco/HitFinder/HitFinderTools/ICandidateHitFinder.h
+++ b/larreco/HitFinder/HitFinderTools/ICandidateHitFinder.h
@@ -46,9 +46,9 @@ namespace reco_tool
 
         // Search for candidate hits on the input waveform
         virtual void findHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t&, // Waveform (with range info) to analyze
-                                       size_t,                                               // waveform start tick
-                                       size_t,                                               // channel #
-                                       size_t,                                               // Event count (for histograms)
+                                       const size_t,                                               // waveform start tick
+                                       const size_t,                                               // channel #
+                                       const size_t,                                               // Event count (for histograms)
                                        HitCandidateVec&) const = 0;                          // output candidate hits
 
         virtual void MergeHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t&,

--- a/larreco/HitFinder/HitFinderTools/PeakFitterMrqdt_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/PeakFitterMrqdt_tool.cc
@@ -140,7 +140,7 @@ namespace reco_tool
     if (!fitResult){
       int fitResult2=fMarqFitAlg->gshf::MarqFitAlg::cal_perr(&p[0],&y[0],nParams,roiSize,&perr[0]);
       if (!fitResult2){
-	float NDF = roiSize - nParams;
+	NDF = roiSize - nParams;
 	chi2PerNDF = chiSqr / NDF;
 	int parIdx = 0;
 	for(size_t i=0;i<fhc_vec.size();i++){

--- a/larreco/HitFinder/HitFinderTools/PeakFitterMrqdt_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/PeakFitterMrqdt_tool.cc
@@ -46,7 +46,7 @@ namespace reco_tool
 
     const geo::GeometryCore* fGeometry = lar::providerFrom<geo::Geometry>();
   };
-  
+
   //--------------------------
   //constructor
 
@@ -72,10 +72,10 @@ namespace reco_tool
   }
 
   //------------------------
-  void PeakFitterMrqdt::findPeakParameters(const std::vector<float>&                      signal, 
-					   const ICandidateHitFinder::HitCandidateVec& fhc_vec, 
-					   PeakParamsVec&                              mhpp_vec, 
-					   double&                                     chi2PerNDF, 
+  void PeakFitterMrqdt::findPeakParameters(const std::vector<float>&                      signal,
+					   const ICandidateHitFinder::HitCandidateVec& fhc_vec,
+					   PeakParamsVec&                              mhpp_vec,
+					   double&                                     chi2PerNDF,
 					   int&                                        NDF) const
   {
     if(fhc_vec.empty()) return;
@@ -145,7 +145,7 @@ namespace reco_tool
 	int parIdx = 0;
 	for(size_t i=0;i<fhc_vec.size();i++){
 
-	  /* stand alone method  
+	  /* stand alone method
 	  mhpp_vec[i].peakAmplitude      = p[parIdx + 0];
 	  mhpp_vec[i].peakAmplitudeError = perr[parIdx + 0];
 	  mhpp_vec[i].peakCenter         = p[parIdx + 1] + 0.5 + float(startTime);
@@ -153,17 +153,17 @@ namespace reco_tool
 	  mhpp_vec[i].peakSigma          = p[parIdx + 2];
 	  mhpp_vec[i].peakSigmaError     = perr[parIdx + 2];
 	  */
-	  
-	  PeakFitParams_t mhpp;	  
+
+	  PeakFitParams_t mhpp;
 	  mhpp.peakAmplitude      = p[parIdx + 0];
           mhpp.peakAmplitudeError = perr[parIdx + 0];
           mhpp.peakCenter         = p[parIdx + 1] + 0.5 + float(startTime); //shift by 0.5 to account for bin width
           mhpp.peakCenterError    = perr[parIdx + 1];
           mhpp.peakSigma          = std::abs(p[parIdx + 2]);
           mhpp.peakSigmaError     = perr[parIdx + 2];
-  
+
 	  mhpp_vec.emplace_back(mhpp);
-	  
+
 	  parIdx += 3;
 
 	}


### PR DESCRIPTION
This pull request changes the loop over wires in the GausHitFinder_module from a simple for loop to a tbb::parallel_for. Concurrent pushing of results in the output vector is handled via tbb::concurrent_vector. Credits to @sberkman for the initial implementation. Thread scaling performance is currently under study. The PR also includes a bug fix in the PeakFitterMrqdt_tool, so that the number of degrees of freedom (NDF) is now properly returned.