### PR TITLE
Including missing configuration in clustermodules.fcl

### DIFF
--- a/larreco/ClusterFinder/clustermodules.fcl
+++ b/larreco/ClusterFinder/clustermodules.fcl
@@ -1,3 +1,4 @@
+#include "hitalgorithms.fcl"
 #include "clusteralgorithms.fcl"
 #include "showeralgorithms.fcl"
 


### PR DESCRIPTION
One of the configurations therein requires `standard_cchitfinderalg`, defined `larreco/RecoAlg/hitalgorithms.fcl`.
Without including it, `clustermodules.fcl` can't be used stand-alone.

This pull request is based on the assumption that it should be possible to include `clustermodules.fcl` in a configuration file without _explicitly_ including anything more.

Breaking change
--------------------------

Due to how FHiCL work, there is a _potential_ for breaking existing configuration. For example, a configuration like:
```
#include "hitalgorithms.fcl"

BEGIN_PROLOG
standard_cchitfinderalg.MaxBumps: 10
END_PROLOG

#include "clustermodules.fcl"
```
would be affected since in the original `standard_cchitfinderalg.MaxBumps` might still be `10` (instead of `5` as defined in `hitalgorithms.fcl`), while with the new change it will be restored to `5` by the inclusion of `clustermodules.fcl`.

**Opinions are welcome.**
