### PR TITLE
Fixed MagneticField service for nug4 v1_07_00

### DIFF
--- a/larreco/TrackFinder/CMakeLists.txt
+++ b/larreco/TrackFinder/CMakeLists.txt
@@ -7,7 +7,7 @@ art_make(EXCLUDE
            KalmanFilterFitTrackMaker_tool.cc
          MODULE_LIBRARIES
            larreco_RecoAlg
-           nug4_MagneticField_MagneticField_service
+           nug4_MagneticFieldServices_MagneticFieldServiceStandard_service
            ROOT::Core
            ${MF_MESSAGELOGGER}
          )

--- a/larreco/TrackFinder/MagDriftAna_module.cc
+++ b/larreco/TrackFinder/MagDriftAna_module.cc
@@ -34,7 +34,7 @@
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "larsim/MCCheater/BackTrackerService.h"
-#include "nug4/MagneticField/MagneticField.h"
+#include "nug4/MagneticFieldServices/MagneticFieldService.h" 
 
 /// Detector simulation of raw signals on wires
 namespace hit {
@@ -104,7 +104,9 @@ namespace hit {
     auto const detProp =
       art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
 
-    art::ServiceHandle<mag::MagneticField const> MagField;
+    // art::ServiceHandle<mag::MagneticField const> MagField;
+    art::ServiceHandle<mag::MagneticFieldService const> MagFieldHandle;
+    auto const* MagField = MagFieldHandle->provider();
     double Efield = detProp.Efield();
     double Temperature = detProp.Temperature();
     double DriftVelocity = detProp.DriftVelocity(Efield, Temperature) / 1000.;


### PR DESCRIPTION
Fix MagneticField service in TrackFinder due to modifications of the MagneticField service in the nug4 package (v1_07_00)
See issue: https://cdcvs.fnal.gov/redmine/issues/25534 