### PR TITLE
Move MarqFitAlg to larvecutils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ find_ups_product( lardataalg )
 find_ups_product( lardata )
 find_ups_product( larevt )
 find_ups_product( larsim )
+find_ups_product( larvecutils )
 
 # macros for dictionary and simple_plugin
 include(ArtDictionary)

--- a/larreco/HitFinder/HitFinderTools/CMakeLists.txt
+++ b/larreco/HitFinder/HitFinderTools/CMakeLists.txt
@@ -6,6 +6,7 @@ set( hitfinder_tool_lib_list
                         lardataobj_RecoBase
                         larcore_Geometry_Geometry_service
                         lardata_Utilities
+                        larvecutils_MarqFitAlg
                         nurandom::RandomUtils_NuRandomService_service
                         art::Framework_Core
                         art::Framework_Principal

--- a/larreco/HitFinder/HitFinderTools/PeakFitterMrqdt_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/PeakFitterMrqdt_tool.cc
@@ -1,4 +1,4 @@
-#include "lardata/Utilities/MarqFitAlg.h" //marqfit functions
+#include "larvecutils/MarqFitAlg/MarqFitAlg.h" //marqfit functions
 #include "larreco/HitFinder/HitFinderTools/IPeakFitter.h"
 #include "larreco/RecoAlg/GausFitCache.h" // hit::GausFitCache
 


### PR DESCRIPTION
This PR updates the larreco package after migration of MarqFitAlg to the newly created larvecutils package.