### PR TITLE
GausHitFinder ROI loop with tbb

### DIFF
--- a/larreco/HitFinder/GausHitFinder_module.cc
+++ b/larreco/HitFinder/GausHitFinder_module.cc
@@ -317,7 +317,10 @@ namespace hit {
         // #################################################
         const recob::Wire::RegionsOfInterest_t& signalROI = wire->SignalROI();
 
-        for (const auto& range : signalROI.get_ranges()) {
+        // for (const auto& range : signalROI.get_ranges()) {
+	tbb::parallel_for(static_cast<std::size_t>(0),signalROI.n_ranges(),
+			  [&](size_t& rangeIter){
+	  const auto& range = signalROI.range(rangeIter);
           // ROI start time
           raw::TDCtick_t roiFirstBinTick = range.begin_index();
 
@@ -561,6 +564,8 @@ namespace hit {
           } //<---End loop over merged candidate hits
 
         } //<---End looping over ROI's
+	);//end tbb parallel for
+
       }   //<---End looping over all the wires
     );    //end tbb parallel for
 


### PR DESCRIPTION
This PR changes the loop over ROI in GausHitFinder_module.cc from a simple `for` into a `tbb::parallel_for`. Note that the outer loop over wires is already a `tbb::parallel_for`, so this code is thread safe (when used with thread safe tools). Adding an extra layer of parallelization allows tbb to reduce thread imbalance. This is a non-breaking change, and the output should be unchanged.