### PR TITLE
solution for pandoraTrack to deal with invalid points

### DIFF
--- a/larreco/RecoAlg/TrackMomentumCalculator.cxx
+++ b/larreco/RecoAlg/TrackMomentumCalculator.cxx
@@ -491,7 +491,7 @@ namespace trkf {
 
   double
   TrackMomentumCalculator::GetMomentumMultiScatterChi2(
-    const art::Ptr<recob::Track>& trk)
+    const art::Ptr<recob::Track>& trk, const bool checkValidPoints)
   {
     std::vector<float> recoX;
     std::vector<float> recoY;

--- a/larreco/RecoAlg/TrackMomentumCalculator.cxx
+++ b/larreco/RecoAlg/TrackMomentumCalculator.cxx
@@ -500,6 +500,7 @@ namespace trkf {
     int n_points = trk->NumberTrajectoryPoints();
 
     for (int i = 0; i < n_points; i++) {
+      if (checkValidPoints && !trk->HasValidPoint(i)) continue;
       auto const& pos = trk->LocationAtPoint(i);
       recoX.push_back(pos.X());
       recoY.push_back(pos.Y());

--- a/larreco/RecoAlg/TrackMomentumCalculator.h
+++ b/larreco/RecoAlg/TrackMomentumCalculator.h
@@ -24,7 +24,7 @@ namespace trkf {
                             double maxLength = 1350.0);
 
     double GetTrackMomentum(double trkrange, int pdg) const;
-    double GetMomentumMultiScatterChi2(art::Ptr<recob::Track> const& trk, bool checkValidPoints = false);
+    double GetMomentumMultiScatterChi2(art::Ptr<recob::Track> const& trk, const bool checkValidPoints = false);
     double GetMomentumMultiScatterLLHD(art::Ptr<recob::Track> const& trk);
     double GetMuMultiScatterLLHD3(art::Ptr<recob::Track> const& trk, bool dir);
     TVector3 GetMultiScatterStartingPoint(art::Ptr<recob::Track> const& trk);

--- a/larreco/RecoAlg/TrackMomentumCalculator.h
+++ b/larreco/RecoAlg/TrackMomentumCalculator.h
@@ -24,7 +24,7 @@ namespace trkf {
                             double maxLength = 1350.0);
 
     double GetTrackMomentum(double trkrange, int pdg) const;
-    double GetMomentumMultiScatterChi2(art::Ptr<recob::Track> const& trk);
+    double GetMomentumMultiScatterChi2(art::Ptr<recob::Track> const& trk, bool checkValidPoints = false);
     double GetMomentumMultiScatterLLHD(art::Ptr<recob::Track> const& trk);
     double GetMuMultiScatterLLHD3(art::Ptr<recob::Track> const& trk, bool dir);
     TVector3 GetMultiScatterStartingPoint(art::Ptr<recob::Track> const& trk);


### PR DESCRIPTION
In TrackMomentrumCalculator.cxx, in order to implement the MCS method, it requires to loop over the points belong to the same track. However, for pandoraTrack, there are always some invalid trajectory points at the end of recob::Track::LocationAtPoint which have value -999 for x/y/z. Here I added the function to check whether the point is valid using recob::Track::HasValidPoint.