### PR TITLE
Add in tool interface to normalize dQ/dx for the Gnocchi Calorimetry module

### DIFF
--- a/larreco/Calorimetry/INormalizeCharge.h
+++ b/larreco/Calorimetry/INormalizeCharge.h
@@ -1,0 +1,35 @@
+/**
+ *  @file   INormalizeCharge.h
+ *
+ *  @brief  This is an interface for an art Tool which scales charge by some 
+ *          factor given information about its associated hit.
+ *
+ *  @author grayputnam@uchicago.edu
+ *
+ */
+#ifndef INormalizeCharge_h
+#define INormalizeCharge_h
+
+// Framework Includes
+#include "fhiclcpp/ParameterSet.h"
+#include "art/Framework/Principal/Event.h"
+#include "lardataobj/RecoBase/Hit.h"
+#include "lardataobj/RecoBase/TrackingTypes.h"
+
+/**
+ *  @brief  INormalizeCharge interface class definiton
+ */
+class INormalizeCharge
+{
+public:
+    /**
+     *  @brief  Virtual Destructor
+     */
+    virtual ~INormalizeCharge() noexcept = default;
+
+    virtual void configure(const fhicl::ParameterSet&) = 0;
+    virtual double Normalize(double dQdx, const art::Event& e, const recob::Hit &h, const geo::Point_t &location, const geo::Vector_t &direction, double t0) = 0;
+};
+
+#endif
+

--- a/larreco/Calorimetry/calorimetry.fcl
+++ b/larreco/Calorimetry/calorimetry.fcl
@@ -54,6 +54,7 @@ standard_gnocchicalo:
   TrackIsFieldDistortionCorrected: false
   Cryostat: 0
   CaloAlg: @local::standard_calorimetryalgdata
+  NormTools: []
 }
 
 standard_generalcalorimetry:


### PR DESCRIPTION
This integrates a tool interface for normalizing charge response in the Gnocchi Calorimetry module, used by SBN. This change is backwards compatible (the `NormTools` parameter defaults to an empty list). This is needed to integrate ICARUS calorimetry with its calibration procedure. The update is designed to be extensible to other detectors that may need a similar interface.  