### PR TITLE
Add N+1 peak fitting

### DIFF
--- a/larreco/HitFinder/HitFinderTools/HitFinderTools.fcl
+++ b/larreco/HitFinder/HitFinderTools/HitFinderTools.fcl
@@ -48,12 +48,16 @@ candhitfinder_standard:
 
 peakfitter_gaussian:
 {
-    tool_type:     "PeakFitterGaussian"
-    MinWidth:      0.5
-    MaxWidthMult:  3.
-    PeakRangeFact: 2.
-    PeakAmpRange:  2.
-    FloatBaseline: false
+    tool_type:        "PeakFitterGaussian"
+    MinWidth:         0.5
+    MaxWidthMult:     3.
+    PeakRangeFact:    2.
+    PeakAmpRange:     2.
+    FloatBaseline:    false
+    Refit:            false
+    RefitThreshold:   40
+    RefitImprovement: 2
+
 }
 
 peakfitter_mrqdt:

--- a/larreco/HitFinder/HitFinderTools/PeakFitterGaussian_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/PeakFitterGaussian_tool.cc
@@ -224,6 +224,10 @@ namespace reco_tool {
     if (!fitResult) {
       GetFitParameters(Gaus, peakParamsVec, nGaus, startTime, chi2PerNDF, NDF);
 
+      // TODO: The refit functionality should be split out into a dedicated tool that will take in
+      // the fit previous fit result, find the new parameters for the refit, and call a
+      // fitting tool to perform the refit. This would enable the use with any fitting tool
+      // rather than being bound within this tool.
       if (fRefit && chi2PerNDF > fRefitThreshold &&
           chi2PerNDF < std::numeric_limits<double>::infinity()) {
 

--- a/larreco/HitFinder/HitFinderTools/PeakFitterGaussian_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/PeakFitterGaussian_tool.cc
@@ -65,12 +65,15 @@ namespace reco_tool {
 
   private:
     // Member variables from the fhicl file
-    const double fMinWidth;       ///< minimum initial width for gaussian fit
-    const double fMaxWidthMult;   ///< multiplier for max width for gaussian fit
-    const double fPeakRange;      ///< set range limits for peak center
-    const double fAmpRange;       ///< set range limit for peak amplitude
-    const bool fFloatBaseline;    ///< Allow baseline to "float" away from zero
-    const bool fOutputHistograms; ///< If true will generate summary style histograms
+    const double fMinWidth;         ///< minimum initial width for gaussian fit
+    const double fMaxWidthMult;     ///< multiplier for max width for gaussian fit
+    const double fPeakRange;        ///< set range limits for peak center
+    const double fAmpRange;         ///< set range limit for peak amplitude
+    const bool fFloatBaseline;      ///< Allow baseline to "float" away from zero
+    const bool fOutputHistograms;   ///< If true will generate summary style histograms
+    const bool fRefit;              ///< If true will attempt to refit with an extra Gaussian
+    const double fRefitThreshold;   ///< Reduced Chi2 threshold above which to refit
+    const double fRefitImprovement; ///< Factor by which the refit must improve the chi2
 
     TH1F* fNumCandHitsHist;
     TH1F* fROISizeHist;
@@ -88,6 +91,18 @@ namespace reco_tool {
     mutable TH1F fHistogram;
 
     const geo::GeometryCore* fGeometry = lar::providerFrom<geo::Geometry>();
+
+    ICandidateHitFinder::HitCandidate FindRefitCand(
+      const TF1& fittedGaus,
+      const std::vector<float>& waveform,
+      const int startTime,
+      const int roiSize,
+      const ICandidateHitFinder::HitCandidateVec& hitCandidateVec,
+      const PeakParamsVec& fittedPeakVec) const;
+
+    std::pair<ICandidateHitFinder::HitCandidate, PeakFitParams_t> FindShiftedGaussian(
+      const ICandidateHitFinder::HitCandidateVec& hitCandidateVec,
+      const PeakParamsVec& fittedPeakVec) const;
   };
 
   //----------------------------------------------------------------------
@@ -99,6 +114,9 @@ namespace reco_tool {
     , fAmpRange(pset.get<double>("PeakAmpRange", 2.))
     , fFloatBaseline(pset.get<bool>("FloatBaseline", false))
     , fOutputHistograms(pset.get<bool>("OutputHistograms", false))
+    , fRefit(pset.get<bool>("Refit"))
+    , fRefitThreshold(pset.get<double>("RefitThreshold"))
+    , fRefitImprovement(pset.get<double>("RefitImprovement"))
   {
     fHistogram = TH1F("PeakFitterHitSignal", "", 500, 0., 500.);
 
@@ -163,28 +181,10 @@ namespace reco_tool {
     for (int idx = 0; idx < roiSize; idx++)
       fHistogram.SetBinContent(idx + 1, roiSignalVec[startTime + idx]);
 
-      // Build the string to describe the fit formula
-#if 0
-    std::string equation = "gaus(0)";
-
-    for(size_t idx = 1; idx < hitCandidateVec.size(); idx++) equation += "+gaus(" + std::to_string(3*idx) + ")";
-
-    // Set the baseline if so desired
-    float baseline(0.);
-
-    if (fFloatBaseline)
-    {
-        baseline = roiSignalVec[startTime];
-
-        equation += "+" + std::to_string(baseline);
-    }
-
-    // Now define the complete function to fit
-    TF1 Gaus("Gaus",equation.c_str(),0,roiSize,TF1::EAddToList::kNo);
-#else
+    // Build the string to describe the fit formula
     unsigned int const nGaus = hitCandidateVec.size();
     assert(fFitCache.Get(nGaus));
-    TF1& Gaus = *(fFitCache.Get(nGaus));
+    TF1 Gaus = *(fFitCache.Get(nGaus));
 
     // Set the baseline if so desired
     float baseline(0.);
@@ -196,8 +196,6 @@ namespace reco_tool {
     }
     else
       Gaus.FixParameter(nGaus * 3, baseline); // last parameter is the baseline
-
-#endif // 0
 
     if (fOutputHistograms) {
       fNumCandHitsHist->Fill(hitCandidateVec.size(), 1.);
@@ -270,12 +268,221 @@ namespace reco_tool {
         parIdx += 3;
       }
 
+      if (fRefit && chi2PerNDF > fRefitThreshold &&
+          chi2PerNDF < std::numeric_limits<double>::infinity()) {
+
+        const ICandidateHitFinder::HitCandidate refitParams =
+          FindRefitCand(Gaus, roiSignalVec, startTime, roiSize, hitCandidateVec, peakParamsVec);
+
+        if (refitParams.hitHeight > 0) {
+
+          ICandidateHitFinder::HitCandidateVec newHitCandidateVec = hitCandidateVec;
+          newHitCandidateVec.push_back(refitParams);
+
+          // Build the string to describe the fit formula
+          unsigned int const nGausNew = nGaus + 1;
+          assert(fFitCache.Get(nGausNew));
+          Gaus = *(fFitCache.Get(nGausNew));
+
+          // ### Setting the parameters for the Gaussian Fit ###
+          int parIdx{0};
+          for (auto const& candidateHit : newHitCandidateVec) {
+            double const peakMean = candidateHit.hitCenter - float(startTime);
+            double const peakWidth = candidateHit.hitSigma;
+            double const amplitude = candidateHit.hitHeight - baseline;
+            double const meanLowLim = std::max(peakMean - fPeakRange * peakWidth, 0.);
+            double const meanHiLim = std::min(peakMean + fPeakRange * peakWidth, double(roiSize));
+            double const widthLim = std::min(fMaxWidthMult * peakWidth,
+                                             double(roiSize) / (2 * newHitCandidateVec.size()));
+
+            if (fOutputHistograms) {
+              fCandPeakPositionHist->Fill(peakMean, 1.);
+              fCandPeakWidHist->Fill(peakWidth, 1.);
+              fCandPeakAmpitudeHist->Fill(amplitude, 1.);
+            }
+
+            Gaus.SetParameter(parIdx, amplitude);
+            Gaus.SetParameter(1 + parIdx, peakMean);
+            Gaus.SetParameter(2 + parIdx, peakWidth);
+            Gaus.SetParLimits(parIdx, 0.1 * amplitude, fAmpRange * amplitude);
+            Gaus.SetParLimits(1 + parIdx, meanLowLim, meanHiLim);
+            Gaus.SetParLimits(2 + parIdx, std::max(fMinWidth, 0.1 * peakWidth), widthLim);
+
+            parIdx += 3;
+          }
+
+          int newFitResult{-1};
+          try {
+            newFitResult = fHistogram.Fit(&Gaus, "QNWB", "", 0., roiSize);
+          }
+          catch (...) {
+            mf::LogWarning("GausHitFinder") << "Fitter failed finding a hit";
+          }
+
+          // If the fit result is not zero there was an error
+          if (!newFitResult) {
+            // ##################################################
+            // ### Getting the fitted parameters from the fit ###
+            // ##################################################
+            float newChi2PerNDF = (Gaus.GetChisquare() / Gaus.GetNDF());
+
+            if (newChi2PerNDF * fRefitImprovement < chi2PerNDF || newChi2PerNDF < fRefitThreshold) {
+              peakParamsVec.clear();
+
+              chi2PerNDF = (Gaus.GetChisquare() / Gaus.GetNDF());
+              NDF = Gaus.GetNDF();
+
+              int parIdx{0};
+              for (size_t idx = 0; idx < nGausNew; idx++) {
+                PeakFitParams_t peakParams;
+
+                peakParams.peakAmplitude = Gaus.GetParameter(parIdx);
+                peakParams.peakAmplitudeError = Gaus.GetParError(parIdx);
+                peakParams.peakCenter = Gaus.GetParameter(parIdx + 1) + float(startTime);
+                peakParams.peakCenterError = Gaus.GetParError(parIdx + 1);
+                peakParams.peakSigma = Gaus.GetParameter(parIdx + 2);
+                peakParams.peakSigmaError = Gaus.GetParError(parIdx + 2);
+
+                peakParamsVec.emplace_back(peakParams);
+
+                parIdx += 3;
+              }
+            }
+          }
+        }
+      }
+
       if (fOutputHistograms) fFitBaselineHist->Fill(Gaus.GetParameter(3 * nGaus), 1.);
     }
-#if 0
-    Gaus.Delete();
-#endif // 0
     return;
+  }
+
+  ICandidateHitFinder::HitCandidate PeakFitterGaussian::FindRefitCand(
+    const TF1& fittedGaus,
+    const std::vector<float>& waveform,
+    const int startTime,
+    const int roiSize,
+    const ICandidateHitFinder::HitCandidateVec& hitCandidateVec,
+    const PeakParamsVec& fittedPeakVec) const
+  {
+
+    // Find the candidate that was shifted most by the fit
+    std::pair<ICandidateHitFinder::HitCandidate, PeakFitParams_t> shiftedHitCanPair =
+      FindShiftedGaussian(hitCandidateVec, fittedPeakVec);
+
+    // If the candidate was shifted more than some given amount, place a new candidate on the other side
+    float offset(shiftedHitCanPair.second.peakCenter - shiftedHitCanPair.first.hitCenter);
+
+    // If we have too many Gaussians it is just a mess
+    if (std::abs(offset) > 1.f && hitCandidateVec.size() == 1) {
+
+      offset = std::min(offset, roiSize / 8.f);
+
+      const int candPos(
+        offset > 0 ?
+          std::min(shiftedHitCanPair.first.hitCenter + 4.f * offset,
+                   (shiftedHitCanPair.first.hitCenter + shiftedHitCanPair.first.stopTick) / 2.f) :
+          std::max(shiftedHitCanPair.first.hitCenter + 4.f * offset,
+                   (shiftedHitCanPair.first.hitCenter + shiftedHitCanPair.first.startTick) / 2.f));
+
+      return ICandidateHitFinder::HitCandidate{0,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               float(candPos + startTime),
+                                               3.f * std::abs(offset),
+                                               0.5f * waveform[candPos]};
+    }
+
+    // If we are not trying a  peak that was shifted, find the largest diff between fitted and input
+    int maxDiffPos(std::numeric_limits<int>::max());
+    float maxDiff(0);
+    for (int i = 0; i < roiSize; i++) {
+      float diff(waveform[startTime + i] - fittedGaus.Eval(i));
+
+      // Prefer excesses over deficits
+      if (diff > 0) diff *= 1.25;
+
+      diff *= diff;
+
+      // We want to avoid adding new Gaussians in the tails
+      float peakDist(std::numeric_limits<float>::max());
+      for (auto const& hitCandidate : hitCandidateVec)
+        peakDist = std::min(peakDist, std::abs(hitCandidate.hitCenter - float(startTime) - i));
+
+      // Or too close to a peak
+      if (peakDist < 3) continue;
+
+      diff *= std::log(peakDist);
+
+      if (std::abs(diff) > std::abs(maxDiff)) {
+        maxDiff = diff;
+        maxDiffPos = i;
+      }
+    }
+
+    if (maxDiffPos == std::numeric_limits<int>::max())
+      return ICandidateHitFinder::HitCandidate{0,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               std::numeric_limits<float>::lowest(),
+                                               std::numeric_limits<float>::lowest(),
+                                               std::numeric_limits<float>::lowest()};
+
+    // Recover the actual diff
+    maxDiff = (waveform[startTime + maxDiffPos] - fittedGaus.Eval(maxDiffPos));
+
+    int lowLim(maxDiffPos);
+    int highLim(maxDiffPos);
+    const bool useMax(maxDiff > 0);
+
+    // Find the point where the excess crosses the fitted Gaussian
+    if (useMax) {
+      while (lowLim > 0 && waveform[startTime + lowLim] > fittedGaus.Eval(lowLim))
+        lowLim--;
+
+      while (highLim < roiSize && waveform[startTime + highLim] > fittedGaus.Eval(highLim))
+        highLim++;
+    }
+    else {
+      while (lowLim > 0 && waveform[startTime + lowLim] < fittedGaus.Eval(lowLim))
+        lowLim--;
+
+      while (highLim < roiSize && waveform[startTime + highLim] < fittedGaus.Eval(highLim))
+        highLim++;
+    }
+
+    const float amplitude(std::max(std::abs(2 * maxDiff), waveform[startTime + maxDiffPos] / 2.f));
+
+    return ICandidateHitFinder::HitCandidate{
+      0, 0, 0, 0, 0, 0, float(maxDiffPos + startTime), 0.5f * (highLim - lowLim), amplitude};
+  }
+
+  std::pair<ICandidateHitFinder::HitCandidate, IPeakFitter::PeakFitParams_t>
+  PeakFitterGaussian::FindShiftedGaussian(
+    const ICandidateHitFinder::HitCandidateVec& hitCandidateVec,
+    const PeakParamsVec& fittedPeakVec) const
+  {
+    float minDiff(std::numeric_limits<float>::max());
+    ICandidateHitFinder::HitCandidate const* minHit;
+    PeakFitParams_t const* minPeak;
+
+    for (auto const& hitCand : hitCandidateVec) {
+      for (auto const& fittedPeak : fittedPeakVec) {
+        const float offset(hitCand.hitCenter - fittedPeak.peakCenter);
+        if (std::abs(offset) < minDiff) {
+          minDiff = offset;
+          minHit = &hitCand;
+          minPeak = &fittedPeak;
+        }
+      }
+    }
+    return std::pair<ICandidateHitFinder::HitCandidate, PeakFitParams_t>(*minHit, *minPeak);
   }
 
   DEFINE_ART_CLASS_TOOL(PeakFitterGaussian)


### PR DESCRIPTION
This PR re-adds a feature to try and fit N+1 Gaussians when fitting N yields poor results that was removed when the hit finding was refactored to use tools. This re-implementation tries to be much smarter about the initial parameters of the extra Gaussian should be added. 

This feature is disabled by default so no changes to existing workflows are expected. 