### PR TITLE
INormalizeCharge interface extension to allow per-event setup.

### DIFF
--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -220,6 +220,8 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
   // must be valid if the T0 module label is non-empty
   art::FindManyP<anab::T0> fmT0s(trackListHandle, evt, fConfig.T0ModuleLabel());
 
+  for (auto const& nt : fNormTools) nt->setup(evt);
+  
   // iterate over all the tracks
   for (unsigned trk_i = 0; trk_i < tracklist.size(); trk_i++) {
     const recob::Track& track = *tracklist[trk_i];

--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -220,8 +220,9 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
   // must be valid if the T0 module label is non-empty
   art::FindManyP<anab::T0> fmT0s(trackListHandle, evt, fConfig.T0ModuleLabel());
 
-  for (auto const& nt : fNormTools) nt->setup(evt);
-  
+  for (auto const& nt : fNormTools)
+    nt->setup(evt);
+
   // iterate over all the tracks
   for (unsigned trk_i = 0; trk_i < tracklist.size(); trk_i++) {
     const recob::Track& track = *tracklist[trk_i];

--- a/larreco/Calorimetry/INormalizeCharge.h
+++ b/larreco/Calorimetry/INormalizeCharge.h
@@ -27,6 +27,7 @@ public:
   virtual ~INormalizeCharge() noexcept = default;
 
   virtual void configure(const fhicl::ParameterSet&) = 0;
+  virtual void setup(const art::Event&) {}
   virtual double Normalize(double dQdx,
                            const art::Event& e,
                            const recob::Hit& h,


### PR DESCRIPTION
This request is for support to SBNSoftware/icaruscode#543.

The `INormalizeCharge` interface is extended to support a "setup" stage where the tool is expected to extract whatever it needs from the event.

A default no-op implementation is provided.
One of the implementations of this interface in `icaruscode` will use it to cache the detector clocks data.

Note that the current interface already allows access to the event on each normalisation call; therefore alternative approaches are also possible that do not change the interface at all, e.g. caching the detector clocks data at the first call, and for the following calls refresh the cache only if the event ID has changed. This approach has all the usual drawbacks (more cumbersome, has a minor overhead and makes multithreading more complicate).

I yield to @gputnam, author of the current version of the code, for a judgement on this approach.