### PR TITLE
Updates track momentum calculator

### DIFF
--- a/larreco/RecoAlg/TrackMomentumCalculator.cxx
+++ b/larreco/RecoAlg/TrackMomentumCalculator.cxx
@@ -872,6 +872,8 @@ namespace trkf {
         vz.push_back(z0);
       }
       else if (dr1 > seg_size) {
+
+        i = (i - 1); // In this case, we keep at the same point until seg_size is reached
         double const dx = x1 - x0;
         double const dy = y1 - y0;
         double const dz = z1 - z0;

--- a/larreco/RecoAlg/TrackMomentumCalculator.cxx
+++ b/larreco/RecoAlg/TrackMomentumCalculator.cxx
@@ -244,6 +244,7 @@ namespace trkf {
   // email: kalousis@vt.edu
 
   double TrackMomentumCalculator::GetMomentumMultiScatterLLHD(const art::Ptr<recob::Track>& trk,
+                                                              const bool checkValidPoints,
                                                               const int maxMomentum_MeV,
                                                               const int MomentumStep_MeV,
                                                               const int max_resolution)
@@ -255,6 +256,7 @@ namespace trkf {
     int n_points = trk->NumberTrajectoryPoints();
 
     for (int i = 0; i < n_points; i++) {
+      if (checkValidPoints && !trk->HasValidPoint(i)) continue;
       auto const& pos = trk->LocationAtPoint(i);
       recoX.push_back(pos.X());
       recoY.push_back(pos.Y());

--- a/larreco/RecoAlg/TrackMomentumCalculator.cxx
+++ b/larreco/RecoAlg/TrackMomentumCalculator.cxx
@@ -61,7 +61,7 @@ namespace {
   TVector3 const basex{1, 0, 0};
   TVector3 const basey{0, 1, 0};
   TVector3 const basez{0, 0, 1};
-  constexpr float kcal{0.0024};
+  constexpr float kcal{0.0024}; // Approximation of dE/dx for mip muon in LAr
 
   class FcnWrapper {
   public:
@@ -95,7 +95,8 @@ namespace {
         constexpr double rad_length{14.0};
         double const l0 = xx / rad_length;
         double res1 = 0.0;
-
+        // Highland formula
+        // Parameters given at Particle Data Group https://pdg.lbl.gov/2023/web/viewer.html?file=../reviews/rpp2022-rev-passage-particles-matter.pdf
         if (xx > 0 && p > 0) res1 = (13.6 / p) * std::sqrt(l0) * (1.0 + 0.038 * std::log(l0));
 
         res1 = std::sqrt(res1 * res1 + theta0 * theta0);
@@ -104,6 +105,7 @@ namespace {
         result += cet::square(diff / ey);
       }
 
+      // Adds a penalty for higher resolutions
       result += 2.0 / (4.6) * theta0; // *std::log( 1.0/14.0 );
 
       if (std::isnan(result) || std::isinf(result)) {
@@ -381,13 +383,14 @@ namespace trkf {
     auto const& segL = segments.L;
 
     int tot = a1 - 1;
-    double thick1 = thick + 0.13;
+    double thick1 = thick + 0.13; // adds a small offset to the 10 cm segment
 
     for (int i = 0; i < tot; i++) {
       double const dx = segnx.at(i);
       double const dy = segny.at(i);
       double const dz = segnz.at(i);
 
+      // Assumes z as propagation angle
       TVector3 const vec_z{dx, dy, dz};
       TVector3 vec_x;
       TVector3 vec_y;
@@ -409,6 +412,7 @@ namespace trkf {
 
       double const refL = segL.at(i);
 
+      // Now loop over next segments until thick1 is reached in the next segment
       for (int j = i; j < tot; j++) {
         double const L1 = segL.at(j);
         double const L2 = segL.at(j + 1);
@@ -431,21 +435,21 @@ namespace trkf {
           double const azy = find_angle(scz, scy);
           double const azx = find_angle(scz, scx);
 
-          constexpr double ULim = 10000.0;
+          constexpr double ULim = 10000.0; // Avoid huge (wrong) angles
           constexpr double LLim = -10000.0;
 
           double const cL = kcal;
           double const Li = segL.at(i);
           double const Lj = segL.at(j);
 
-          if (azy <= ULim && azy >= LLim) {
-            ei.push_back(Li * cL);
-            ej.push_back(Lj * cL);
-            th.push_back(azy);
+          if (azy <= ULim && azy >= LLim) { // save scatter in the yz plane
+            ei.push_back(Li * cL);          // Energy deposited at i
+            ej.push_back(Lj * cL);          // Energy deposited at j
+            th.push_back(azy);              // scattered angle
             ind.push_back(2);
           }
 
-          if (azx <= ULim && azx >= LLim) {
+          if (azx <= ULim && azx >= LLim) { // save scatter in the za plane
             ei.push_back(Li * cL);
             ej.push_back(Lj * cL);
             th.push_back(azx);
@@ -601,6 +605,111 @@ namespace trkf {
     return true;
   }
 
+  void TrackMomentumCalculator::compute_max_fluctuation_vector(const std::vector<float> segx,
+                                                               const std::vector<float> segy,
+                                                               const std::vector<float> segz,
+                                                               std::vector<float>& segnx,
+                                                               std::vector<float>& segny,
+                                                               std::vector<float>& segnz,
+                                                               std::vector<float>& vx,
+                                                               std::vector<float>& vy,
+                                                               std::vector<float>& vz)
+  {
+    auto const na = vx.size();
+
+    double sumx = 0.0;
+    double sumy = 0.0;
+    double sumz = 0.0;
+
+    for (std::size_t i = 0; i < na; ++i) {
+      sumx += vx.at(i);
+      sumy += vy.at(i);
+      sumz += vz.at(i);
+    }
+
+    sumx /= na;
+    sumy /= na;
+    sumz /= na;
+
+    std::vector<double> mx;
+    std::vector<double> my;
+    std::vector<double> mz;
+
+    TMatrixDSym m(3);
+
+    for (std::size_t i = 0; i < na; ++i) {
+      double const xxw1 = vx.at(i);
+      double const yyw1 = vy.at(i);
+      double const zzw1 = vz.at(i);
+
+      mx.push_back(xxw1 - sumx);
+      my.push_back(yyw1 - sumy);
+      mz.push_back(zzw1 - sumz);
+
+      double const xxw0 = mx.at(i);
+      double const yyw0 = my.at(i);
+      double const zzw0 = mz.at(i);
+
+      m(0, 0) += xxw0 * xxw0 / na;
+      m(0, 1) += xxw0 * yyw0 / na;
+      m(0, 2) += xxw0 * zzw0 / na;
+
+      m(1, 0) += yyw0 * xxw0 / na;
+      m(1, 1) += yyw0 * yyw0 / na;
+      m(1, 2) += yyw0 * zzw0 / na;
+
+      m(2, 0) += zzw0 * xxw0 / na;
+      m(2, 1) += zzw0 * yyw0 / na;
+      m(2, 2) += zzw0 * zzw0 / na;
+    }
+
+    TMatrixDSymEigen me(m);
+
+    TVectorD eigenval = me.GetEigenValues();
+    TMatrixD eigenvec = me.GetEigenVectors();
+
+    double max1 = -666.0;
+
+    double ind1 = 0;
+
+    for (int i = 0; i < 3; ++i) {
+      double const p1 = eigenval(i);
+
+      if (p1 > max1) {
+        max1 = p1;
+        ind1 = i;
+      }
+    }
+
+    double ax = eigenvec(0, ind1);
+    double ay = eigenvec(1, ind1);
+    double az = eigenvec(2, ind1);
+
+    if (n_seg > 1) {
+      if (segx.at(n_seg - 1) - segx.at(n_seg - 2) > 0)
+        ax = std::abs(ax);
+      else
+        ax = -1.0 * std::abs(ax);
+
+      if (segy.at(n_seg - 1) - segy.at(n_seg - 2) > 0)
+        ay = std::abs(ay);
+      else
+        ay = -1.0 * std::abs(ay);
+
+      if (segz.at(n_seg - 1) - segz.at(n_seg - 2) > 0)
+        az = std::abs(az);
+      else
+        az = -1.0 * std::abs(az);
+
+      segnx.push_back(ax);
+      segny.push_back(ay);
+      segnz.push_back(az);
+    }
+    vx.clear();
+    vy.clear();
+    vz.clear();
+  }
+
   std::optional<TrackMomentumCalculator::Segments> TrackMomentumCalculator::getSegTracks_(
     std::vector<float> const& xxx,
     std::vector<float> const& yyy,
@@ -744,110 +853,15 @@ namespace trkf {
         vz.push_back(z0);
 
         ntot++;
-
-        auto const na = vx.size();
-        double sumx = 0.0;
-        double sumy = 0.0;
-        double sumz = 0.0;
-
-        for (std::size_t i = 0; i < na; ++i) {
-          sumx += vx.at(i);
-          sumy += vy.at(i);
-          sumz += vz.at(i);
-        }
-
-        sumx /= na;
-        sumy /= na;
-        sumz /= na;
-
-        std::vector<double> mx;
-        std::vector<double> my;
-        std::vector<double> mz;
-
-        TMatrixDSym m(3);
-
-        for (std::size_t i = 0; i < na; ++i) {
-          double const xxw1 = vx.at(i);
-          double const yyw1 = vy.at(i);
-          double const zzw1 = vz.at(i);
-
-          mx.push_back(xxw1 - sumx);
-          my.push_back(yyw1 - sumy);
-          mz.push_back(zzw1 - sumz);
-
-          double const xxw0 = mx.at(i);
-          double const yyw0 = my.at(i);
-          double const zzw0 = mz.at(i);
-
-          m(0, 0) += xxw0 * xxw0 / na;
-          m(0, 1) += xxw0 * yyw0 / na;
-          m(0, 2) += xxw0 * zzw0 / na;
-
-          m(1, 0) += yyw0 * xxw0 / na;
-          m(1, 1) += yyw0 * yyw0 / na;
-          m(1, 2) += yyw0 * zzw0 / na;
-
-          m(2, 0) += zzw0 * xxw0 / na;
-          m(2, 1) += zzw0 * yyw0 / na;
-          m(2, 2) += zzw0 * zzw0 / na;
-        }
-
-        TMatrixDSymEigen me(m);
-
-        TVectorD eigenval = me.GetEigenValues();
-        TMatrixD eigenvec = me.GetEigenVectors();
-
-        double max1 = -666.0;
-
-        double ind1 = 0;
-
-        for (int i = 0; i < 3; ++i) {
-          double const p1 = eigenval(i);
-
-          if (p1 > max1) {
-            max1 = p1;
-            ind1 = i;
-          }
-        }
-
-        double ax = eigenvec(0, ind1);
-        double ay = eigenvec(1, ind1);
-        double az = eigenvec(2, ind1);
-
-        if (n_seg > 1) {
-          if (segx.at(n_seg - 1) - segx.at(n_seg - 2) > 0)
-            ax = std::abs(ax);
-          else
-            ax = -1.0 * std::abs(ax);
-
-          if (segy.at(n_seg - 1) - segy.at(n_seg - 2) > 0)
-            ay = std::abs(ay);
-          else
-            ay = -1.0 * std::abs(ay);
-
-          if (segz.at(n_seg - 1) - segz.at(n_seg - 2) > 0)
-            az = std::abs(az);
-          else
-            az = -1.0 * std::abs(az);
-
-          segnx.push_back(ax);
-          segny.push_back(ay);
-          segnz.push_back(az);
-        }
-        else
+        if (n_seg <= 1) // This should never happen
           return std::nullopt;
 
-        ntot = 0;
+        compute_max_fluctuation_vector(segx, segy, segz, segnx, segny, segnz, vx, vy, vz);
 
-        vx.clear();
-        vy.clear();
-        vz.clear();
-
+        ntot = 1;
         vx.push_back(x0);
         vy.push_back(y0);
         vz.push_back(z0);
-
-        ntot++;
       }
       else if (dr1 > seg_size) {
         double const dx = x1 - x0;
@@ -879,118 +893,21 @@ namespace trkf {
         y0 = yp;
         z0 = zp;
 
-        i = (i - 1);
-
         vx.push_back(x0);
         vy.push_back(y0);
         vz.push_back(z0);
 
         ntot++;
-
-        double na = vx.size();
-
-        double sumx = 0.0;
-        double sumy = 0.0;
-        double sumz = 0.0;
-
-        for (std::size_t i = 0; i < na; ++i) {
-          sumx += vx.at(i);
-          sumy += vy.at(i);
-          sumz += vz.at(i);
-        }
-
-        sumx /= na;
-        sumy /= na;
-        sumz /= na;
-
-        std::vector<double> mx;
-        std::vector<double> my;
-        std::vector<double> mz;
-
-        TMatrixDSym m(3);
-
-        for (int i = 0; i < na; ++i) {
-          double const xxw1 = vx.at(i);
-          double const yyw1 = vy.at(i);
-          double const zzw1 = vz.at(i);
-
-          mx.push_back(xxw1 - sumx);
-          my.push_back(yyw1 - sumy);
-          mz.push_back(zzw1 - sumz);
-
-          double const xxw0 = mx.at(i);
-          double const yyw0 = my.at(i);
-          double const zzw0 = mz.at(i);
-
-          m(0, 0) += xxw0 * xxw0 / na;
-          m(0, 1) += xxw0 * yyw0 / na;
-          m(0, 2) += xxw0 * zzw0 / na;
-
-          m(1, 0) += yyw0 * xxw0 / na;
-          m(1, 1) += yyw0 * yyw0 / na;
-          m(1, 2) += yyw0 * zzw0 / na;
-
-          m(2, 0) += zzw0 * xxw0 / na;
-          m(2, 1) += zzw0 * yyw0 / na;
-          m(2, 2) += zzw0 * zzw0 / na;
-        }
-
-        TMatrixDSymEigen me(m);
-
-        TVectorD eigenval = me.GetEigenValues();
-        TMatrixD eigenvec = me.GetEigenVectors();
-
-        double max1 = -666.0;
-        double ind1 = 0;
-
-        for (int i = 0; i < 3; ++i) {
-          double const p1 = eigenval(i);
-
-          if (p1 > max1) {
-            max1 = p1;
-            ind1 = i;
-          }
-        }
-
-        double ax = eigenvec(0, ind1);
-        double ay = eigenvec(1, ind1);
-        double az = eigenvec(2, ind1);
-
-        if (n_seg > 1) {
-          if (segx.at(n_seg - 1) - segx.at(n_seg - 2) > 0)
-            ax = std::abs(ax);
-          else
-            ax = -1.0 * std::abs(ax);
-
-          if (segy.at(n_seg - 1) - segy.at(n_seg - 2) > 0)
-            ay = std::abs(ay);
-          else
-            ay = -1.0 * std::abs(ay);
-
-          if (segz.at(n_seg - 1) - segz.at(n_seg - 2) > 0)
-            az = std::abs(az);
-          else
-            az = -1.0 * std::abs(az);
-
-          segnx.push_back(ax);
-          segny.push_back(ay);
-          segnz.push_back(az);
-        }
-
-        else
+        if (n_seg <= 1) // This should never happen
           return std::nullopt;
 
-        ntot = 0;
+        compute_max_fluctuation_vector(segx, segy, segz, segnx, segny, segnz, vx, vy, vz);
 
-        vx.clear();
-        vy.clear();
-        vz.clear();
-
+        // vectors are cleared in previous step
+        ntot = 1;
         vx.push_back(x0);
         vy.push_back(y0);
         vz.push_back(z0);
-
-        ntot++;
       }
 
       if (n_seg >= (stopper + 1.0) && seg_stop != -1) break;
@@ -1195,32 +1112,36 @@ namespace trkf {
     double theta0x = x1;
 
     double result = 0.0;
-    double nnn1 = dEi.size();
+    double nnn1 = dEi.size(); // number of segments of energy
 
     double red_length = (10.0) / 14.0;
     double addth = 0;
 
     for (int i = 0; i < nnn1; i++) {
-      double Ei = p - dEi.at(i);
-      double Ej = p - dEj.at(i);
+      double Ei = p - dEi.at(i); // Estimated energy at point i
+      double Ej = p - dEj.at(i); // Estimated enery at point j
 
+      // If the momentum p choosen allows that the muon stopped inside, add 1 rad to the change in scatter angle (as the particle stops)
       if (Ei > 0 && Ej < 0) addth = 3.14 * 1000.0;
 
       Ei = std::abs(Ei);
       Ej = std::abs(Ej);
 
+      // Highland formula
+      // Parameters given at Particle Data Group https://pdg.lbl.gov/2023/web/viewer.html?file=../reviews/rpp2022-rev-passage-particles-matter.pdf
       double tH0 =
         (13.6 / std::sqrt(Ei * Ej)) * (1.0 + 0.038 * std::log(red_length)) * std::sqrt(red_length);
 
       double rms = -1.0;
 
       if (ind.at(i) == 1) {
-        rms = std::sqrt(tH0 * tH0 + pow(theta0x, 2.0));
+        // Computes the rms of angle
+        rms = std::sqrt(tH0 * tH0 + cet::square(theta0x));
 
         double const DT = dthij.at(i) + addth;
-        double const prob = my_g(DT, 0.0, rms);
+        double const prob = my_g(DT, 0.0, rms); // Computes log likelihood
 
-        result = result - 2.0 * prob;
+        result = result - 2.0 * prob; // Adds for each segment
       }
     }
 

--- a/larreco/RecoAlg/TrackMomentumCalculator.h
+++ b/larreco/RecoAlg/TrackMomentumCalculator.h
@@ -35,7 +35,7 @@ namespace trkf {
 
     double GetTrackMomentum(double trkrange, int pdg) const;
     /**
-    * @brief  Calculate muon momentum (MeV) using multiple coulomb scattering. Chi2 minimization of the Highland formula
+    * @brief  Calculate muon momentum (GeV) using multiple coulomb scattering. Chi2 minimization of the Highland formula
     *
     * @param  trk the muon track
     * @param  checkValidPoints rather take into account only valid points or not
@@ -43,13 +43,13 @@ namespace trkf {
     *
     * TODO: Add better description of the steps done.
     *
-    * @return momentum in MeV
+    * @return momentum in GeV
     */
     double GetMomentumMultiScatterChi2(art::Ptr<recob::Track> const& trk,
                                        const bool checkValidPoints = false,
                                        const int maxMomentum_MeV = 7500);
     /**
-    * @brief  Calculate muon momentum (MeV) using multiple coulomb scattering by log likelihood
+    * @brief  Calculate muon momentum (GeV) using multiple coulomb scattering by log likelihood
     *
     * @param  trk the muon track
     * @param  checkValidPoints rather take into account only valid points or not
@@ -59,7 +59,7 @@ namespace trkf {
     *
     * TODO: Add better description of the steps done
     *
-    * @return momentum in MeV
+    * @return momentum in GeV
     */
     double GetMomentumMultiScatterLLHD(art::Ptr<recob::Track> const& trk,
                                        const bool checkValidPoints = false,
@@ -160,7 +160,7 @@ namespace trkf {
     * @param Q
     * @param s
     *
-    * @return Momentum in MeV
+    * @return Momentum in GeV
     */
     double my_g(double xx, double Q, double s) const;
 
@@ -176,7 +176,7 @@ namespace trkf {
     *
     * TODO: Add better description of steps
     *
-    * @return momentum in MeV
+    * @return momentum in GeV
     */
     double my_mcs_llhd(std::vector<float> const& dEi,
                        std::vector<float> const& dEj,

--- a/larreco/RecoAlg/TrackMomentumCalculator.h
+++ b/larreco/RecoAlg/TrackMomentumCalculator.h
@@ -20,12 +20,50 @@ namespace trkf {
 
   class TrackMomentumCalculator {
   public:
-    TrackMomentumCalculator(double minLength = 100.0, double maxLength = 1350.0);
+    /**
+    * @brief  Constructor
+    *
+    * Parameters are relevant for Multiple Coulomb Scattering
+    *
+    * @param  minLength minimum length in cm of tracks (length here is based on the amout of segments)
+    * @param  maxLength maximum length in cm of tracks (length here is based on the amout of segments)
+    * @param  stes_size size in cm of each segment to compute scattering
+    */
+    TrackMomentumCalculator(double minLength = 100.0,
+                            double maxLength = 1350.0,
+                            double steps_size = 10.);
 
     double GetTrackMomentum(double trkrange, int pdg) const;
+    /**
+    * @brief  Calculate muon momentum (MeV) using multiple coulomb scattering. Chi2 minimization of the Highland formula
+    *
+    * @param  trk the muon track
+    * @param  checkValidPoints rather take into account valid points or not
+    * @param  maxMomentum_MeV maximum momentum in MeV for the minimization
+    *
+    * TODO: Add better description of the steps done.
+    *
+    * @return momentum in MeV
+    */
     double GetMomentumMultiScatterChi2(art::Ptr<recob::Track> const& trk,
-                                       const bool checkValidPoints = false);
-    double GetMomentumMultiScatterLLHD(art::Ptr<recob::Track> const& trk);
+                                       const bool checkValidPoints = false,
+                                       const int maxMomentum_MeV = 7500);
+    /**
+    * @brief  Calculate muon momentum (MeV) using multiple coulomb scattering by log likelihood
+    *
+    * @param  trk the muon track
+    * @param  maxMomentum_MeV maximum momentum in MeV for the minimization
+    * @param  MomentumStep_MeV energy steps for minimization
+    * @param  max_resolution maximum angular resolution for fit. Setting to zero will cause the fit only over momentum and fixed resolution of 2 mrad
+    *
+    * TODO: Add better description of the steps done
+    *
+    * @return momentum in MeV
+    */
+    double GetMomentumMultiScatterLLHD(art::Ptr<recob::Track> const& trk,
+                                       const int maxMomentum_MeV = 7500,
+                                       const int MomentumStep_MeV = 10,
+                                       const int max_resolution = 0);
     double GetMuMultiScatterLLHD3(art::Ptr<recob::Track> const& trk, bool dir);
     TVector3 GetMultiScatterStartingPoint(art::Ptr<recob::Track> const& trk);
 
@@ -34,6 +72,30 @@ namespace trkf {
                          std::vector<float> const& yyy,
                          std::vector<float> const& zzz);
 
+    /**
+    * @brief Computes the vector with most scattering inside a segment with size steps_size
+    * @param segx, segy, segz segments points
+    * @param segnx, segny, segnz vector components to be filled
+    * @param vector used to control points to be used at segments
+    *
+    */
+    void compute_max_fluctuation_vector(const std::vector<float> segx,
+                                        const std::vector<float> segy,
+                                        const std::vector<float> segz,
+                                        std::vector<float>& segnx,
+                                        std::vector<float>& segny,
+                                        std::vector<float>& segnz,
+                                        std::vector<float>& vx,
+                                        std::vector<float>& vy,
+                                        std::vector<float>& vz);
+    /**
+    * \struct Segments
+    * @brief Struct to store segments.
+    * x, y and z are the 3D points of the segment
+    * nx, ny, nz forms the vector that point to the direction of most scattering
+    * L is the length of the segment, using steps_size
+    *
+    */
     struct Segments {
       std::vector<float> x, nx;
       std::vector<float> y, ny;
@@ -41,14 +103,47 @@ namespace trkf {
       std::vector<float> L;
     };
 
+    /**
+    * @brief Split tracks into segments to calculate the scattered angle later. Check DOI 10.1088/1748-0221/12/10/P10010
+    *
+    * @param xxx 3D reconstructed points x-axis
+    * @param yyy 3D reconstructed points y-axiy
+    * @param zzz 3D reconstructed points z-axiz
+    * @seg_size Segments size defined in class constructor
+    *
+    * TODO: Add better description of steps
+    *
+    * @return Segments
+    */
     std::optional<Segments> getSegTracks_(std::vector<float> const& xxx,
                                           std::vector<float> const& yyy,
                                           std::vector<float> const& zzz,
                                           double seg_size);
 
+    /**
+    * @brief Gets the scattered angle RMS for a all segments
+    *
+    * @param segments segments computed
+    * @param thick is the steps_size
+    *
+    * TODO: Add better description of steps
+    *
+    * @return tuple with mean value, rms and error of rms
+    */
     std::tuple<double, double, double> getDeltaThetaRMS_(Segments const& segments,
                                                          double thick) const;
 
+    /**
+    * @brief Gets the scatterd angle for all the segments
+    *
+    * @param ei, ej will be filled with energy lost at point i and j
+    * @param th delta theta to be filled
+    * @param ind selection of scattering plane
+    * @param segments
+    * @param thick is the steps_size
+    *
+    * @return sucess or failure
+    */
     int getDeltaThetaij_(std::vector<float>& ei,
                          std::vector<float>& ej,
                          std::vector<float>& th,
@@ -56,8 +151,31 @@ namespace trkf {
                          Segments const& segments,
                          double thick) const;
 
+    /**
+    * @brief chi square minizer using Minuit2, it will minize (xx-Q)/s
+    *
+    * @param xx
+    * @param Q
+    * @param s
+    *
+    * @return Momentum in MeV
+    */
     double my_g(double xx, double Q, double s) const;
 
+    /**
+    * @brief  Minimizer of log likelihood for scattered angle
+    *
+    * @param  dEi energy at step i
+    * @param  dEj energy at step j
+    * @param  dthij scattered angle between points i and j
+    * @param  ind selection of scattering plane
+    * @param  x0 momentum to be fitted
+    * @param  x1 resolution to be fitted
+    *
+    * TODO: Add better description of steps
+    *
+    * @return momentum in MeV
+    */
     double my_mcs_llhd(std::vector<float> const& dEi,
                        std::vector<float> const& dEj,
                        std::vector<float> const& dthij,
@@ -72,14 +190,23 @@ namespace trkf {
     float y_seg[50000];
     float z_seg[50000];
 
+    /**
+    * @brief Gets angle between two vy and vz
+    *
+    * @param vz
+    * @param vy
+    *
+    * @return angle in mrad
+    */
     double find_angle(double vz, double vy) const;
 
-    float steps_size{10.};
     int n_steps{6};
     std::vector<float> steps;
 
     double minLength;
     double maxLength;
+    double steps_size;
+    double rad_length{14.0};
 
     // The following are objects that are created but not drawn or
     // saved.  This class should consider accepting a "debug"

--- a/larreco/RecoAlg/TrackMomentumCalculator.h
+++ b/larreco/RecoAlg/TrackMomentumCalculator.h
@@ -38,7 +38,7 @@ namespace trkf {
     * @brief  Calculate muon momentum (MeV) using multiple coulomb scattering. Chi2 minimization of the Highland formula
     *
     * @param  trk the muon track
-    * @param  checkValidPoints rather take into account valid points or not
+    * @param  checkValidPoints rather take into account only valid points or not
     * @param  maxMomentum_MeV maximum momentum in MeV for the minimization
     *
     * TODO: Add better description of the steps done.
@@ -52,6 +52,7 @@ namespace trkf {
     * @brief  Calculate muon momentum (MeV) using multiple coulomb scattering by log likelihood
     *
     * @param  trk the muon track
+    * @param  checkValidPoints rather take into account only valid points or not
     * @param  maxMomentum_MeV maximum momentum in MeV for the minimization
     * @param  MomentumStep_MeV energy steps for minimization
     * @param  max_resolution maximum angular resolution for fit. Setting to zero will cause the fit only over momentum and fixed resolution of 2 mrad
@@ -61,6 +62,7 @@ namespace trkf {
     * @return momentum in MeV
     */
     double GetMomentumMultiScatterLLHD(art::Ptr<recob::Track> const& trk,
+                                       const bool checkValidPoints = false,
                                        const int maxMomentum_MeV = 7500,
                                        const int MomentumStep_MeV = 10,
                                        const int max_resolution = 0);

--- a/larreco/RecoAlg/TrackMomentumCalculator.h
+++ b/larreco/RecoAlg/TrackMomentumCalculator.h
@@ -27,7 +27,7 @@ namespace trkf {
     *
     * @param  minLength minimum length in cm of tracks (length here is based on the amout of segments)
     * @param  maxLength maximum length in cm of tracks (length here is based on the amout of segments)
-    * @param  stes_size size in cm of each segment to compute scattering
+    * @param  steps_size size in cm of each segment to compute scattering
     */
     TrackMomentumCalculator(double minLength = 100.0,
                             double maxLength = 1350.0,
@@ -111,7 +111,7 @@ namespace trkf {
     * @param xxx 3D reconstructed points x-axis
     * @param yyy 3D reconstructed points y-axiy
     * @param zzz 3D reconstructed points z-axiz
-    * @seg_size Segments size defined in class constructor
+    * @param seg_size Segments size defined in class constructor
     *
     * TODO: Add better description of steps
     *


### PR DESCRIPTION
## [Added comments to make code clear](https://github.com/LArSoft/larreco/commit/2699c74d6b3c83fa710bc4c93650d7df9d66e2a0)

I struggled a lot understanding the code. I think it would be good to add some comments. If something is wrong or unclear let me know. There are still parts of the code that I want to comment, but might take me a while (also to understand the code)

There was also a block of code that was just being repeated twice ~~(with some 'typo')~~[1], I merged all together in a new function 

## [Changed hard-coded values to parameters. Add description](https://github.com/LArSoft/larreco/commit/5a2b89fd944d70bd03efccf28bfb94f856c24ddd)

I am not changing how the codes work. I tried to add some description for each function that fits doxygen. 

I added as parameters `steps_size` and `maxMomentum_MeV` for MCS method. The limit of 7500 MeV was hard-coded. The steps is to allow us to toggle, but also to avoid repetition. 

For MCS Log Likelihood I also added the `MomentumStep_MeV` for the fitting and `max_resolution` to allow fitting it. 

One thing I noticed is that the log likelihood is not truly a fit. It will scan all possible values with fixed step and find the minimum. I can implement the fit with Minuit2 if that is ok, let me know :) 

--- 
[1] Check last commit. I wrongly removed the line `i=(i-1)`, as below there was a for using `i`. The subtraction makes sense in the context of getting segments of fixed length. In the case `dr1 > seg_size`, a linear interpolation is made and need to keep going (in steps of seg_size)  until `dr1 >= seg_size`.