### PR TITLE
Feature/howard larreco to use gptunam changes

### DIFF
--- a/larreco/Calorimetry/CalorimetryAlg.cxx
+++ b/larreco/Calorimetry/CalorimetryAlg.cxx
@@ -26,6 +26,10 @@ namespace calo {
     , fUseModBox{config.CaloUseModBox()}
     , fLifeTimeForm{config.CaloLifeTimeForm()}
     , fDoLifeTimeCorrection{config.CaloDoLifeTimeCorrection()}
+    , fModBoxA{config.ModBoxA()}
+    , fModBoxBF("ModBoxB", config.ModBoxBTF1().c_str(), 0, 90)
+    , fBirksA{config.BirksA()}
+    , fBirksKF("BirksK", config.BirksKTF1().c_str(), 0, 90)
   {
     if (fLifeTimeForm != 0 and fLifeTimeForm != 1) {
       throw cet::exception("CalorimetryAlg")
@@ -33,6 +37,22 @@ namespace calo {
         << "Must select either '0' for exponential or '1' for exponential + "
            "constant.\n";
     }
+
+    // Set the parameters for the TF1s
+    std::vector<double> modboxb_param;
+    if (!config.ModBoxBParam(modboxb_param)) modboxb_param = {util::kModBoxB};
+
+    for (unsigned i = 0; i < modboxb_param.size(); i++) {
+      fModBoxBF.SetParameter(i, modboxb_param[i]);
+    }
+
+    std::vector<double> birksk_param;
+    if (!config.BirksKParam(birksk_param)) birksk_param = {util::kRecombk};
+
+    for (unsigned i = 0; i < birksk_param.size(); i++) {
+      fBirksKF.SetParameter(i, birksk_param[i]);
+    }
+
   }
 
   //------------------------------------------------------------------------------------//
@@ -51,20 +71,6 @@ namespace calo {
                     hit.WireID().Plane,
                     T0,
                     det_prop.Efield());
-  }
-
-  ///\todo The plane argument should really be for a view instead
-  // ----------------------------------------------------------------------------------//
-  double CalorimetryAlg::dEdx_AMP(detinfo::DetectorClocksData const& clock_data,
-                                  detinfo::DetectorPropertiesData const& det_prop,
-                                  double const dQ,
-                                  double const time,
-                                  double const pitch,
-                                  unsigned int const plane,
-                                  double const T0) const
-  {
-    double const dQdx = dQ / pitch; // in ADC/cm
-    return dEdx_AMP(clock_data, det_prop, dQdx, time, plane, T0, det_prop.Efield());
   }
 
   // ----------------------------------------------------------------------------------//
@@ -88,7 +94,8 @@ namespace calo {
                                   recob::Hit const& hit,
                                   double const pitch,
                                   double const T0,
-                                  double const EField) const
+                                  double const EField,
+                                  double const phi) const
   {
     return dEdx_AMP(clock_data,
                     det_prop,
@@ -96,22 +103,8 @@ namespace calo {
                     hit.PeakTime(),
                     hit.WireID().Plane,
                     T0,
-                    EField);
-  }
-
-  ///\todo The plane argument should really be for a view instead
-  // ----------------------------------------------------------------------------------//
-  double CalorimetryAlg::dEdx_AMP(detinfo::DetectorClocksData const& clock_data,
-                                  detinfo::DetectorPropertiesData const& det_prop,
-                                  double const dQ,
-                                  double const time,
-                                  double const pitch,
-                                  unsigned int const plane,
-                                  double const T0,
-                                  double const EField) const
-  {
-    double const dQdx = dQ / pitch; // in ADC/cm
-    return dEdx_AMP(clock_data, det_prop, dQdx, time, plane, T0, EField);
+                    EField,
+                    phi);
   }
 
   // ----------------------------------------------------------------------------------//
@@ -121,11 +114,12 @@ namespace calo {
                                   double const time,
                                   unsigned int const plane,
                                   double const T0,
-                                  double const EField) const
+                                  double const EField,
+                                  double const phi) const
   {
     double const fADCtoEl = fCalAmpConstants[plane];
     double const dQdx_e = dQdx / fADCtoEl; // Conversion from ADC/cm to e/cm
-    return dEdx_from_dQdx_e(clock_data, det_prop, dQdx_e, time, T0, EField);
+    return dEdx_from_dQdx_e(clock_data, det_prop, dQdx_e, time, T0, EField, phi);
   }
 
   //------------------------------------------------------------------------------------//
@@ -149,19 +143,6 @@ namespace calo {
   // ----------------------------------------------------------------------------------//
   double CalorimetryAlg::dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
                                    detinfo::DetectorPropertiesData const& det_prop,
-                                   double const dQ,
-                                   double const time,
-                                   double const pitch,
-                                   unsigned int const plane,
-                                   double const T0) const
-  {
-    double const dQdx = dQ / pitch; // in ADC/cm
-    return dEdx_AREA(clock_data, det_prop, dQdx, time, plane, T0, det_prop.Efield());
-  }
-
-  // ----------------------------------------------------------------------------------//
-  double CalorimetryAlg::dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
-                                   detinfo::DetectorPropertiesData const& det_prop,
                                    double const dQdx,
                                    double const time,
                                    unsigned int const plane,
@@ -180,24 +161,11 @@ namespace calo {
                                    recob::Hit const& hit,
                                    double const pitch,
                                    double const T0,
-                                   double const EField) const
+                                   double const EField,
+                                   double const phi) const
   {
     return dEdx_AREA(
-      clock_data, det_prop, hit.Integral() / pitch, hit.PeakTime(), hit.WireID().Plane, T0, EField);
-  }
-
-  // ----------------------------------------------------------------------------------//
-  double CalorimetryAlg::dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
-                                   detinfo::DetectorPropertiesData const& det_prop,
-                                   double const dQ,
-                                   double const time,
-                                   double const pitch,
-                                   unsigned int const plane,
-                                   double const T0,
-                                   double const EField) const
-  {
-    double const dQdx = dQ / pitch; // in ADC/cm
-    return dEdx_AREA(clock_data, det_prop, dQdx, time, plane, T0, EField);
+      clock_data, det_prop, hit.Integral() / pitch, hit.PeakTime(), hit.WireID().Plane, T0, EField, phi);
   }
 
   // ----------------------------------------------------------------------------------//
@@ -207,11 +175,12 @@ namespace calo {
                                    double const time,
                                    unsigned int const plane,
                                    double const T0,
-                                   double const EField) const
+                                   double const EField,
+                                   double const phi) const
   {
     double const fADCtoEl = fCalAreaConstants[plane];
     double const dQdx_e = dQdx / fADCtoEl; // Conversion from ADC/cm to e/cm
-    return dEdx_from_dQdx_e(clock_data, det_prop, dQdx_e, time, T0, EField);
+    return dEdx_from_dQdx_e(clock_data, det_prop, dQdx_e, time, T0, EField, phi);
   }
 
   // Apply Lifetime and recombination correction.
@@ -228,15 +197,16 @@ namespace calo {
                                           double dQdx_e,
                                           double const time,
                                           double const T0,
-                                          double const EField) const
+                                          double const EField,
+                                          double const phi) const
   {
     if (fDoLifeTimeCorrection) {
       dQdx_e *= LifetimeCorrection(clock_data, det_prop, time, T0); // (dQdx_e in e/cm)
     }
 
-    if (fUseModBox) { return det_prop.ModBoxCorrection(dQdx_e, EField); }
+    if (fUseModBox) { return ModBoxCorrection(dQdx_e, phi, det_prop.Density(), EField); }
 
-    return det_prop.BirksCorrection(dQdx_e, EField);
+    return BirksCorrection(dQdx_e, phi, det_prop.Density(), EField);
   }
 
   //------------------------------------------------------------------------------------//
@@ -264,5 +234,38 @@ namespace calo {
       art::ServiceHandle<lariov::ElectronLifetimeService const>()->GetProvider();
     return elifetime_provider.Lifetime(adjusted_time);
   }
+
+  // Reombination corrections
+
+  // Modified box: allow for a general behavior of beta from phi, the angle between the track 
+  // and the electric field
+  double calo::CalorimetryAlg::ModBoxCorrection(double dQdx, double phi, double rho, double E_field) const
+  {
+    // Modified Box model correction has better behavior than the Birks
+    // correction at high values of dQ/dx.
+    constexpr double Wion = 1000. / util::kGeVToElectrons; // 23.6 eV = 1e, Wion in MeV/e
+    double const Beta = fModBoxBF.Eval(phi) / (rho * E_field);
+    double const Alpha = fModBoxA;
+    double const dEdx = (exp(Beta * Wion * dQdx) - Alpha) / Beta;
+
+    return dEdx;
+  }
+
+  double calo::CalorimetryAlg::BirksCorrection(double dQdx, double phi, double rho, double E_field) const
+  {
+    // from: S.Amoruso et al., NIM A 523 (2004) 275
+
+    double A = fBirksA;
+    double K = fBirksKF.Eval(phi);                              // in KV/cm*(g/cm^2)/MeV
+    constexpr double Wion = 1000. / util::kGeVToElectrons;      // 23.6 eV = 1e, Wion in MeV/e
+    K /= rho;                                                   // KV/MeV
+    double const dEdx = dQdx / (A / Wion - K / E_field * dQdx); // MeV/cm
+    
+    return dEdx;
+  }
+
+
+
+
 
 } // namespace

--- a/larreco/Calorimetry/CalorimetryAlg.cxx
+++ b/larreco/Calorimetry/CalorimetryAlg.cxx
@@ -52,7 +52,6 @@ namespace calo {
     for (unsigned i = 0; i < birksk_param.size(); i++) {
       fBirksKF.SetParameter(i, birksk_param[i]);
     }
-
   }
 
   //------------------------------------------------------------------------------------//
@@ -164,8 +163,14 @@ namespace calo {
                                    double const EField,
                                    double const phi) const
   {
-    return dEdx_AREA(
-      clock_data, det_prop, hit.Integral() / pitch, hit.PeakTime(), hit.WireID().Plane, T0, EField, phi);
+    return dEdx_AREA(clock_data,
+                     det_prop,
+                     hit.Integral() / pitch,
+                     hit.PeakTime(),
+                     hit.WireID().Plane,
+                     T0,
+                     EField,
+                     phi);
   }
 
   // ----------------------------------------------------------------------------------//
@@ -237,9 +242,12 @@ namespace calo {
 
   // Reombination corrections
 
-  // Modified box: allow for a general behavior of beta from phi, the angle between the track 
+  // Modified box: allow for a general behavior of beta from phi, the angle between the track
   // and the electric field
-  double calo::CalorimetryAlg::ModBoxCorrection(double dQdx, double phi, double rho, double E_field) const
+  double calo::CalorimetryAlg::ModBoxCorrection(double dQdx,
+                                                double phi,
+                                                double rho,
+                                                double E_field) const
   {
     // Modified Box model correction has better behavior than the Birks
     // correction at high values of dQ/dx.
@@ -251,7 +259,10 @@ namespace calo {
     return dEdx;
   }
 
-  double calo::CalorimetryAlg::BirksCorrection(double dQdx, double phi, double rho, double E_field) const
+  double calo::CalorimetryAlg::BirksCorrection(double dQdx,
+                                               double phi,
+                                               double rho,
+                                               double E_field) const
   {
     // from: S.Amoruso et al., NIM A 523 (2004) 275
 
@@ -260,12 +271,8 @@ namespace calo {
     constexpr double Wion = 1000. / util::kGeVToElectrons;      // 23.6 eV = 1e, Wion in MeV/e
     K /= rho;                                                   // KV/MeV
     double const dEdx = dQdx / (A / Wion - K / E_field * dQdx); // MeV/cm
-    
+
     return dEdx;
   }
-
-
-
-
 
 } // namespace

--- a/larreco/Calorimetry/CalorimetryAlg.h
+++ b/larreco/Calorimetry/CalorimetryAlg.h
@@ -12,10 +12,14 @@
 #include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/types/Sequence.h"
 #include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/OptionalSequence.h"
 
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcoreobj/SimpleTypesAndConstants/PhysicalConstants.h"
 #include "lardataobj/RecoBase/Hit.h"
+
+#include "TF1.h"
 
 #include <vector>
 
@@ -52,6 +56,42 @@ namespace calo {
 
       fhicl::Atom<bool> CaloDoLifeTimeCorrection{Name("CaloDoLifeTimeCorrection"),
                                                  Comment("Apply lifetime correction if true")};
+
+      fhicl::Atom<double> ModBoxA {
+        Name("ModBoxA"),
+        Comment("Alpha value in modified box recombination."),
+        util::kModBoxA
+      };
+
+      fhicl::Atom<std::string> ModBoxBTF1 {
+        Name("ModBoxBTF1"),
+        Comment("String compiled into a TF1. Should return the Mod-Box beta value as a function of phi."),
+        "[0]"
+      };
+
+      fhicl::OptionalSequence<double> ModBoxBParam {
+        Name("ModBoxBParam"),
+        Comment("Parameters for the ModBoxBTF1 function.")
+      };
+
+      fhicl::Atom<double> BirksA {
+        Name("BirksA"),
+        Comment("Alpha value in modified box recombination."),
+        util::kRecombA
+      };
+
+      fhicl::Atom<std::string> BirksKTF1 {
+        Name("BirksKTF1"),
+        Comment("String compiled into a TF1. Should return the Birks k value as a function of phi."),
+        "[0]"
+      };
+
+      fhicl::OptionalSequence<double> BirksKParam {
+        Name("BirksKParam"),
+        Comment("Parameters for the BirksKTF1 function. List of doubles.")
+      };
+
+
     };
 
     CalorimetryAlg(const fhicl::ParameterSet& pset)
@@ -67,39 +107,25 @@ namespace calo {
                     double T0 = 0) const;
     double dEdx_AMP(detinfo::DetectorClocksData const& clock_data,
                     detinfo::DetectorPropertiesData const& det_prop,
-                    double dQ,
-                    double time,
-                    double pitch,
-                    unsigned int plane,
-                    double T0 = 0) const;
-    double dEdx_AMP(detinfo::DetectorClocksData const& clock_data,
-                    detinfo::DetectorPropertiesData const& det_prop,
                     double dQdx,
                     double time,
                     unsigned int plane,
                     double T0 = 0) const;
-
     double dEdx_AMP(detinfo::DetectorClocksData const& clock_data,
                     detinfo::DetectorPropertiesData const& det_prop,
                     recob::Hit const& hit,
                     double pitch,
                     double T0,
-                    double EField) const;
-    double dEdx_AMP(detinfo::DetectorClocksData const& clock_data,
-                    detinfo::DetectorPropertiesData const& det_prop,
-                    double dQ,
-                    double time,
-                    double pitch,
-                    unsigned int plane,
-                    double T0,
-                    double EField) const;
+                    double EField,
+                    double phi=90) const;
     double dEdx_AMP(detinfo::DetectorClocksData const& clock_data,
                     detinfo::DetectorPropertiesData const& det_prop,
                     double dQdx,
                     double time,
                     unsigned int plane,
                     double T0,
-                    double EField) const;
+                    double EField,
+                    double phi=90) const;
 
     // FIXME: How may of these are actually used?
     double dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
@@ -109,39 +135,25 @@ namespace calo {
                      double T0 = 0) const;
     double dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
                      detinfo::DetectorPropertiesData const& det_prop,
-                     double dQ,
-                     double time,
-                     double pitch,
-                     unsigned int plane,
-                     double T0 = 0) const;
-    double dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
-                     detinfo::DetectorPropertiesData const& det_prop,
                      double dQdx,
                      double time,
                      unsigned int plane,
                      double T0 = 0) const;
-
     double dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
                      detinfo::DetectorPropertiesData const& det_prop,
                      recob::Hit const& hit,
                      double pitch,
                      double T0,
-                     double EField) const;
-    double dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
-                     detinfo::DetectorPropertiesData const& det_prop,
-                     double dQ,
-                     double time,
-                     double pitch,
-                     unsigned int plane,
-                     double T0,
-                     double EField) const;
+                     double EField,
+                     double phi=90) const;
     double dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
                      detinfo::DetectorPropertiesData const& det_prop,
                      double dQdx,
                      double time,
                      unsigned int plane,
                      double T0,
-                     double EField) const;
+                     double EField,
+                     double phi=90) const;
 
     double ElectronsFromADCPeak(double adc, unsigned short plane) const
     {
@@ -158,6 +170,10 @@ namespace calo {
                               double time,
                               double T0 = 0) const;
 
+    // Recombination corrections
+    double BirksCorrection(double dQdx, double phi, double rho, double E_field) const;
+    double ModBoxCorrection(double dQdx, double phi, double rho, double E_field) const;
+
   private:
     art::ServiceHandle<geo::Geometry const> geom;
 
@@ -171,13 +187,20 @@ namespace calo {
                             double dQdx_e,
                             double time,
                             double T0,
-                            double EField) const;
+                            double EField,
+                            double phi=90) const;
 
     std::vector<double> const fCalAmpConstants;
     std::vector<double> const fCalAreaConstants;
     bool const fUseModBox;
     int const fLifeTimeForm;
     bool const fDoLifeTimeCorrection;
+
+    // Recombination parameters
+    double fModBoxA; // Mod-Box alpha
+    TF1 fModBoxBF; // Function of phi to get the Mod-Box beta value
+    double fBirksA; // Birks A cosntant
+    TF1 fBirksKF; // Function of phi to get the Birks-k value
 
   }; // class CalorimetryAlg
 } // namespace calo

--- a/larreco/Calorimetry/CalorimetryAlg.h
+++ b/larreco/Calorimetry/CalorimetryAlg.h
@@ -10,9 +10,9 @@
 #define UTIL_CALORIMETRYALG_H
 
 #include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/OptionalSequence.h"
 #include "fhiclcpp/types/Sequence.h"
 #include "fhiclcpp/types/Table.h"
-#include "fhiclcpp/types/OptionalSequence.h"
 
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "larcore/Geometry/Geometry.h"
@@ -57,41 +57,33 @@ namespace calo {
       fhicl::Atom<bool> CaloDoLifeTimeCorrection{Name("CaloDoLifeTimeCorrection"),
                                                  Comment("Apply lifetime correction if true")};
 
-      fhicl::Atom<double> ModBoxA {
-        Name("ModBoxA"),
-        Comment("Alpha value in modified box recombination."),
-        util::kModBoxA
-      };
+      fhicl::Atom<double> ModBoxA{Name("ModBoxA"),
+                                  Comment("Alpha value in modified box recombination."),
+                                  util::kModBoxA};
 
-      fhicl::Atom<std::string> ModBoxBTF1 {
+      fhicl::Atom<std::string> ModBoxBTF1{
         Name("ModBoxBTF1"),
-        Comment("String compiled into a TF1. Should return the Mod-Box beta value as a function of phi."),
-        "[0]"
-      };
+        Comment(
+          "String compiled into a TF1. Should return the Mod-Box beta value as a function of phi."),
+        "[0]"};
 
-      fhicl::OptionalSequence<double> ModBoxBParam {
+      fhicl::OptionalSequence<double> ModBoxBParam{
         Name("ModBoxBParam"),
-        Comment("Parameters for the ModBoxBTF1 function.")
-      };
+        Comment("Parameters for the ModBoxBTF1 function.")};
 
-      fhicl::Atom<double> BirksA {
-        Name("BirksA"),
-        Comment("Alpha value in modified box recombination."),
-        util::kRecombA
-      };
+      fhicl::Atom<double> BirksA{Name("BirksA"),
+                                 Comment("Alpha value in modified box recombination."),
+                                 util::kRecombA};
 
-      fhicl::Atom<std::string> BirksKTF1 {
+      fhicl::Atom<std::string> BirksKTF1{
         Name("BirksKTF1"),
-        Comment("String compiled into a TF1. Should return the Birks k value as a function of phi."),
-        "[0]"
-      };
+        Comment(
+          "String compiled into a TF1. Should return the Birks k value as a function of phi."),
+        "[0]"};
 
-      fhicl::OptionalSequence<double> BirksKParam {
+      fhicl::OptionalSequence<double> BirksKParam{
         Name("BirksKParam"),
-        Comment("Parameters for the BirksKTF1 function. List of doubles.")
-      };
-
-
+        Comment("Parameters for the BirksKTF1 function. List of doubles.")};
     };
 
     CalorimetryAlg(const fhicl::ParameterSet& pset)
@@ -117,7 +109,7 @@ namespace calo {
                     double pitch,
                     double T0,
                     double EField,
-                    double phi=90) const;
+                    double phi = 90) const;
     double dEdx_AMP(detinfo::DetectorClocksData const& clock_data,
                     detinfo::DetectorPropertiesData const& det_prop,
                     double dQdx,
@@ -125,7 +117,7 @@ namespace calo {
                     unsigned int plane,
                     double T0,
                     double EField,
-                    double phi=90) const;
+                    double phi = 90) const;
 
     // FIXME: How may of these are actually used?
     double dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
@@ -145,7 +137,7 @@ namespace calo {
                      double pitch,
                      double T0,
                      double EField,
-                     double phi=90) const;
+                     double phi = 90) const;
     double dEdx_AREA(detinfo::DetectorClocksData const& clock_data,
                      detinfo::DetectorPropertiesData const& det_prop,
                      double dQdx,
@@ -153,7 +145,7 @@ namespace calo {
                      unsigned int plane,
                      double T0,
                      double EField,
-                     double phi=90) const;
+                     double phi = 90) const;
 
     double ElectronsFromADCPeak(double adc, unsigned short plane) const
     {
@@ -188,7 +180,7 @@ namespace calo {
                             double time,
                             double T0,
                             double EField,
-                            double phi=90) const;
+                            double phi = 90) const;
 
     std::vector<double> const fCalAmpConstants;
     std::vector<double> const fCalAreaConstants;
@@ -198,9 +190,9 @@ namespace calo {
 
     // Recombination parameters
     double fModBoxA; // Mod-Box alpha
-    TF1 fModBoxBF; // Function of phi to get the Mod-Box beta value
-    double fBirksA; // Birks A cosntant
-    TF1 fBirksKF; // Function of phi to get the Birks-k value
+    TF1 fModBoxBF;   // Function of phi to get the Mod-Box beta value
+    double fBirksA;  // Birks A cosntant
+    TF1 fBirksKF;    // Function of phi to get the Birks-k value
 
   }; // class CalorimetryAlg
 } // namespace calo

--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -283,6 +283,10 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
         // Get the EField
         double EField = GetEfield(det_prop, track, hits[hit_index], thms[hit_index]);
 
+        // Angle to the drift electric field (in x direction), in units of degrees
+        geo::Vector_t direction = track.DirectionAtPoint(thms[hit_index]->Index());
+        double phi = acos(abs(direction.x()))*180/M_PI;
+
         double dQdx = charge / pitch;
 
         // Normalize out the detector response
@@ -301,14 +305,16 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
                                           hits[hit_index]->PeakTime(),
                                           hits[hit_index]->WireID().Plane,
                                           T0,
-                                          EField) :
+                                          EField,
+                                          phi) :
                         fCaloAlg.dEdx_AREA(clock_data,
                                            det_prop,
                                            dQdx,
                                            hits[hit_index]->PeakTime(),
                                            hits[hit_index]->WireID().Plane,
                                            T0,
-                                           EField);
+                                           EField,
+                                           phi);
 
         // save the length between each pair of hits
         if (xyzs.size() == 0) { lengths.push_back(0.); }

--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -285,7 +285,7 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
 
         // Angle to the drift electric field (in x direction), in units of degrees
         geo::Vector_t direction = track.DirectionAtPoint(thms[hit_index]->Index());
-        double phi = acos(abs(direction.x()))*180/M_PI;
+        double phi = acos(abs(direction.x())) * 180 / M_PI;
 
         double dQdx = charge / pitch;
 


### PR DESCRIPTION
Hi - This is actually *not* meant to be a PR against `develop` but I can't make a PR against a tag (`v09_17_06` is what I'm after).

Some ICARUS analyzers (myself included) would like to make an updated version of an older release useful for reprocessing reconstruction and calibration for some ongoing analyses. One of these changes is to introduce the angular dependence introduced by Gray Putnam in `larreco` commits already merged to develop, we just want these to be available in our version. The feature branch on my fork is meant to be `tag: v09_17_06, tag: LARSOFT_SUITE_v09_72_00` with Gray's commits added)

Starting a PR here to get that conversation going and will point some of the relevant SBN/ICARUS release managers/software coordinators here.

(And please let me know if there is a better way to make it go against a proper working area!)