### PR TITLE
Allowing to indirectly associate T0s to Tracks via PFPs in GnocchiCalorimetry

### DIFF
--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -77,18 +77,15 @@ namespace calo {
                                                 Comment("Module label for track producer.")};
 
       fhicl::Atom<std::string> T0ModuleLabel{Name("T0ModuleLabel"),
-                                             Comment("Module label for T0 time producer."),
-                                             ""};
+                                             Comment("Module label for T0 time producer.")};
       fhicl::Atom<std::string> PFPModuleLabel{
         Name("PFPModuleLabel"),
-        Comment("Module label for PFP producer. To be used to associate T0 with tracks."),
-        ""};
+        Comment("Module label for PFP producer. To be used to associate T0 with tracks.")};
 
       fhicl::Atom<std::string> AssocHitModuleLabel{
         Name("AssocHitModuleLabel"),
         Comment("Module label for association between tracks and hits. If not set, defaults to "
-                "TrackModuleLabel."),
-        ""};
+                "TrackModuleLabel.")};
 
       fhicl::Atom<unsigned> ChargeMethod{
         Name("ChargeMethod"),

--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -25,9 +25,9 @@
 #include "lardataobj/AnalysisBase/Calorimetry.h"
 #include "lardataobj/AnalysisBase/T0.h"
 #include "lardataobj/RecoBase/Hit.h"
+#include "lardataobj/RecoBase/PFParticle.h"
 #include "lardataobj/RecoBase/Track.h"
 #include "lardataobj/RecoBase/TrackHitMeta.h"
-#include "lardataobj/RecoBase/PFParticle.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusService.h"
 
@@ -79,9 +79,10 @@ namespace calo {
       fhicl::Atom<std::string> T0ModuleLabel{Name("T0ModuleLabel"),
                                              Comment("Module label for T0 time producer."),
                                              ""};
-      fhicl::Atom<std::string> PFPModuleLabel{Name("PFPModuleLabel"),
-                                             Comment("Module label for PFP producer. To be used to associate T0 with tracks."),
-                                             ""};
+      fhicl::Atom<std::string> PFPModuleLabel{
+        Name("PFPModuleLabel"),
+        Comment("Module label for PFP producer. To be used to associate T0 with tracks."),
+        ""};
 
       fhicl::Atom<std::string> AssocHitModuleLabel{
         Name("AssocHitModuleLabel"),
@@ -222,7 +223,6 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
                                   fConfig.AssocHitModuleLabel();
   art::FindManyP<recob::Hit, recob::TrackHitMeta> fmHits(trackListHandle, evt, hitLabel);
 
-
   // must be valid if the T0 module label is non-empty
   art::FindManyP<anab::T0> fmT0s(trackListHandle, evt, fConfig.T0ModuleLabel());
   art::FindManyP<recob::PFParticle> fmPFPs(trackListHandle, evt, fConfig.TrackModuleLabel());
@@ -249,11 +249,12 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
     double T0 = 0;
     if (fConfig.T0ModuleLabel().size()) {
       if (fConfig.PFPModuleLabel().size()) {
-	const std::vector<art::Ptr<anab::T0>>& this_t0s = fmPFPT0s.at(trk_i);
-	if (this_t0s.size()) T0 = this_t0s.at(0)->Time();
-      } else {
-	const std::vector<art::Ptr<anab::T0>>& this_t0s = fmT0s.at(trk_i);
-	if (this_t0s.size()) T0 = this_t0s.at(0)->Time();
+        const std::vector<art::Ptr<anab::T0>>& this_t0s = fmPFPT0s.at(trk_i);
+        if (this_t0s.size()) T0 = this_t0s.at(0)->Time();
+      }
+      else {
+        const std::vector<art::Ptr<anab::T0>>& this_t0s = fmT0s.at(trk_i);
+        if (this_t0s.size()) T0 = this_t0s.at(0)->Time();
       }
     }
 

--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -225,7 +225,7 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
 
   // must be valid if the T0 module label is non-empty
   art::FindManyP<anab::T0> fmT0s(trackListHandle, evt, fConfig.T0ModuleLabel());
-  art::FindManyP<recob::PFParticle> fmPFPs(trackListHandle, evt, fConfig.PFPModuleLabel());
+  art::FindManyP<recob::PFParticle> fmPFPs(trackListHandle, evt, fConfig.TrackModuleLabel());
   std::vector<art::Ptr<recob::PFParticle>> pfpList;
   if (fConfig.PFPModuleLabel().size()) {
     for (std::size_t itrk = 0, sz = fmPFPs.size(); itrk < sz; ++itrk) {

--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -113,8 +113,7 @@ namespace calo {
       fhicl::Atom<float> FieldDistortionCorrectionXSign{
         Name("FieldDistortionCorrectionXSign"),
         Comment("Sign of the field distortion correction to be applied in the X direction. "
-                "Positive by default."),
-        1.};
+                "Positive by default.")};
 
       fhicl::Table<calo::CalorimetryAlg::Config> CalorimetryAlgConfig{
         Name("CaloAlg"),

--- a/larreco/Calorimetry/calorimetry.fcl
+++ b/larreco/Calorimetry/calorimetry.fcl
@@ -49,6 +49,9 @@ standard_gnocchicalo:
   SpacePointModuleLabel: "spacepointfinder"
   T0ModuleLabel: ""
   AssocHitModuleLabel: ""
+  PFPModuleLabel: "" # NEW! Needed if T0ModuleLabel provided and input data
+                     # have associations PFParticle<->T0 and
+                     # PFPaticle <-> Track, but no direct T0 <-> Track.
   ChargeMethod: 1
   FieldDistortion: false
   TrackIsFieldDistortionCorrected: false

--- a/larreco/Calorimetry/calorimetry.fcl
+++ b/larreco/Calorimetry/calorimetry.fcl
@@ -46,7 +46,6 @@ standard_gnocchicalo:
 {
   module_type: "GnocchiCalorimetry"
   TrackModuleLabel: "track3d"
-  SpacePointModuleLabel: "spacepointfinder"
   T0ModuleLabel: ""
   AssocHitModuleLabel: ""
   PFPModuleLabel: "" # NEW! Needed if T0ModuleLabel provided and input data
@@ -58,6 +57,7 @@ standard_gnocchicalo:
   ChargeMethod: 1
   FieldDistortion: false
   TrackIsFieldDistortionCorrected: false
+  FieldDistortionCorrectionXSign: 1.
   Cryostat: 0
   CaloAlg: @local::standard_calorimetryalgdata
   NormTools: []
@@ -102,7 +102,7 @@ standard_printcalorimetry:
 standard_calocheck: {
   module_type: CaloChecker
   TrackLabel: track # overwrite with the track producer
-  CaloLabels: [oldcalo, newcalo] # overwrite with the two Calo producers 
+  CaloLabels: [oldcalo, newcalo] # overwrite with the two Calo producers
 }
 
 END_PROLOG

--- a/larreco/Calorimetry/calorimetry.fcl
+++ b/larreco/Calorimetry/calorimetry.fcl
@@ -52,6 +52,9 @@ standard_gnocchicalo:
   PFPModuleLabel: "" # NEW! Needed if T0ModuleLabel provided and input data
                      # have associations PFParticle<->T0 and
                      # PFPaticle <-> Track, but no direct T0 <-> Track.
+                     # Note -- there is no default value for this parameter in
+                     # the module and one should excplicitly set it to empty
+                     # if they do not want this functionality
   ChargeMethod: 1
   FieldDistortion: false
   TrackIsFieldDistortionCorrected: false


### PR DESCRIPTION
Pandora creates associations between PFParticles and T0s, but GnocchiCalorimetry uses Track::T0 associations. This does an indirect association a la Track <--> PFParticle <--> T0 within GnocchiCalorimetry