### PR TITLE
Reinstate default parameters in Gnocchi

### DIFF
--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -116,7 +116,8 @@ namespace calo {
       fhicl::Atom<float> FieldDistortionCorrectionXSign{
         Name("FieldDistortionCorrectionXSign"),
         Comment("Sign of the field distortion correction to be applied in the X direction. "
-                "Positive by default.")};
+                "Positive by default."),
+        1.f};
 
       fhicl::Table<calo::CalorimetryAlg::Config> CalorimetryAlgConfig{
         Name("CaloAlg"),

--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -79,6 +79,7 @@ namespace calo {
       fhicl::Atom<std::string> T0ModuleLabel{Name("T0ModuleLabel"),
                                              Comment("Module label for T0 time producer."),
                                              ""};
+
       fhicl::Atom<std::string> PFPModuleLabel{
         Name("PFPModuleLabel"),
         Comment("Module label for PFP producer. To be used to associate T0 with tracks."),

--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -77,15 +77,18 @@ namespace calo {
                                                 Comment("Module label for track producer.")};
 
       fhicl::Atom<std::string> T0ModuleLabel{Name("T0ModuleLabel"),
-                                             Comment("Module label for T0 time producer.")};
+                                             Comment("Module label for T0 time producer."),
+                                             ""};
       fhicl::Atom<std::string> PFPModuleLabel{
         Name("PFPModuleLabel"),
-        Comment("Module label for PFP producer. To be used to associate T0 with tracks.")};
+        Comment("Module label for PFP producer. To be used to associate T0 with tracks."),
+        ""};
 
       fhicl::Atom<std::string> AssocHitModuleLabel{
         Name("AssocHitModuleLabel"),
         Comment("Module label for association between tracks and hits. If not set, defaults to "
-                "TrackModuleLabel.")};
+                "TrackModuleLabel."),
+        ""};
 
       fhicl::Atom<unsigned> ChargeMethod{
         Name("ChargeMethod"),

--- a/larreco/Calorimetry/calorimetry.fcl
+++ b/larreco/Calorimetry/calorimetry.fcl
@@ -51,9 +51,6 @@ standard_gnocchicalo:
   PFPModuleLabel: "" # NEW! Needed if T0ModuleLabel provided and input data
                      # have associations PFParticle<->T0 and
                      # PFPaticle <-> Track, but no direct T0 <-> Track.
-                     # Note -- there is no default value for this parameter in
-                     # the module and one should excplicitly set it to empty
-                     # if they do not want this functionality
   ChargeMethod: 1
   FieldDistortion: false
   TrackIsFieldDistortionCorrected: false


### PR DESCRIPTION
This PR reinstates the default values for the fcl parameter read ins which were removed in a previous PR.  There are default values for
 - `T0ModuleLabel`
 - `AssocHitModuleLabel`
 - `FieldDistortionCorrectionXSign  #default is now a float rather than a double (1.f vs 1.)`
 - `PFPModuleLabel  #This is a new fcl parameter added in the last PR`

This PR is strictly focussed on the default values.  Other items have not been changed or reverted:
 - Handling pfp<->T0<->track association is kept
 - Adding `FieldDistortionCorrectionXSign` as a fcl parameter in calorimetry.fcl has been kept
 - `SpacePointModuleLabel` has not been reinstated in calorimetry.fcl (as it is not used by the producer)

