### PR TITLE
Use the WireReadoutGeom::Plane() method accepting a TPCID and a view instead of PlaneID to make PDDP happy

### DIFF
--- a/larreco/Calorimetry/Calorimetry_module.cc
+++ b/larreco/Calorimetry/Calorimetry_module.cc
@@ -413,7 +413,7 @@ void calo::Calorimetry::produce(art::Event& evt)
               double cosgamma =
                 std::abs(std::sin(angleToVert) * dir.Y() + std::cos(angleToVert) * dir.Z());
               if (cosgamma) {
-                pitch = wireReadoutGeom.Plane({0, 0, vhit[ii]->View()}).WirePitch() / cosgamma;
+                pitch = wireReadoutGeom.Plane({0, 0}, vhit[ii]->View()).WirePitch() / cosgamma;
               }
               else {
                 pitch = 0;

--- a/larreco/RecoAlg/ClusterCrawlerAlg.cxx
+++ b/larreco/RecoAlg/ClusterCrawlerAlg.cxx
@@ -246,8 +246,7 @@ namespace cluster {
         raw::ChannelID_t channel = fHits[fFirstHit].Channel();
         // get the scale factor to convert dTick/dWire to dX/dU. This is used
         // to make the kink and merging cuts
-        float wirePitch =
-          wireReadoutGeom->Plane(tpcid, wireReadoutGeom->View(channel)).WirePitch();
+        float wirePitch = wireReadoutGeom->Plane(tpcid, wireReadoutGeom->View(channel)).WirePitch();
         float tickToDist = det_prop.DriftVelocity(det_prop.Efield(), det_prop.Temperature());
         tickToDist *= 1.e-3 * sampling_rate(clock_data); // 1e-3 is conversion of 1/us to 1/ns
         fScaleF = tickToDist / wirePitch;

--- a/larreco/RecoAlg/ClusterCrawlerAlg.cxx
+++ b/larreco/RecoAlg/ClusterCrawlerAlg.cxx
@@ -247,7 +247,7 @@ namespace cluster {
         // get the scale factor to convert dTick/dWire to dX/dU. This is used
         // to make the kink and merging cuts
         float wirePitch =
-          wireReadoutGeom->Plane({tpcid, wireReadoutGeom->View(channel)}).WirePitch();
+          wireReadoutGeom->Plane(tpcid, wireReadoutGeom->View(channel)).WirePitch();
         float tickToDist = det_prop.DriftVelocity(det_prop.Efield(), det_prop.Temperature());
         tickToDist *= 1.e-3 * sampling_rate(clock_data); // 1e-3 is conversion of 1/us to 1/ns
         fScaleF = tickToDist / wirePitch;


### PR DESCRIPTION
In the V10 refactored geometry, there has been a pattern of finding the wire pitch by querying the WireReadoutGeometry to get a Plane from a PlaneID, and then querying that to get WirePitch.  The issue is that forming the arguments to WireReadoutGeometry::Plane() by using a view instead of a plane number breaks when running ProtoDUNE-DP reconstruction.  The views in PD-DP are numbered 2 and 3, but the planes have different numbers, and these lines throw exceptions.  Fortunately there is a second way of getting a Plane out of WireReadoutGeometry once the view is known, and for the most part, it just involves moving a right-brace over.  There are two instances here, and some in larpandora.