### PR TITLE
put in a check on the iterator for the hit sum accumulation -- end cannot be before begin

### DIFF
--- a/larreco/HitFinder/GausHitFinder_module.cc
+++ b/larreco/HitFinder/GausHitFinder_module.cc
@@ -535,6 +535,7 @@ namespace hit {
 
                 //protection to avoid negative ranges
                 if (newright - newleft < 0) continue;
+		if (HitsumStartItr > HitsumEndItr) continue;
 
                 //avoid ranges out of ROI if it happens
                 if (HitsumStartItr < sumStartItr) HitsumStartItr = sumStartItr;

--- a/larreco/HitFinder/GausHitFinder_module.cc
+++ b/larreco/HitFinder/GausHitFinder_module.cc
@@ -535,7 +535,7 @@ namespace hit {
 
                 //protection to avoid negative ranges
                 if (newright - newleft < 0) continue;
-		if (HitsumStartItr > HitsumEndItr) continue;
+                if (HitsumStartItr > HitsumEndItr) continue;
 
                 //avoid ranges out of ROI if it happens
                 if (HitsumStartItr < sumStartItr) HitsumStartItr = sumStartItr;


### PR DESCRIPTION

In the SBND CI test 

lar -c sbnd_ci_nucosmics_reco1_quick_test_sbndcode.fcl nucosmics_detsim_test_sbndcode_Reference.root

there is a segmentation fault on this line in GausHitFinder_module.cc

                double HitsumADC = std::accumulate(HitsumStartItr, HitsumEndItr, 0.);

Some investigation revealed that in this case, numHits == nGausForFit (==3 in the case of the segfault). While HitsumStartItr and HitsumEndItr start out with the end > start, there is an if condition depending on numHits and nGausForFit that's different for the part that modifies HitsumStartItr and the part that modifies HitsumEndItr.  If in the case numHits == nGausForFit, it happend that the first if clause executed but the second did not, and the variable newright was left at its initialized value, 9999.  To the test on newright vs newleft succeeded, although HitsumEndItr < HitSumStartItr, and the std::accumulate segfaulted.

This PR puts in a bulletproofing check that looks like the one already in there.  It would be good to get feedback from the authors of the algorithm if this is intended behavior, whether skipping around these is the right thing to do, or something would be systematically wrong with the last hits in a group of hits.