### PR TITLE
Change int halfWindowSize to cap the window size

### DIFF
--- a/larreco/HitFinder/HitFinderTools/WaveformTools_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/WaveformTools_tool.cc
@@ -594,7 +594,8 @@ namespace reco_tool {
                                                           Waveform<T>& differenceVec) const
   {
     // Set the window size
-    int halfWindowSize(std::min<int>(structuringElement / 2, static_cast<int>(inputWaveform.size())));
+    int halfWindowSize(
+      std::min<int>(structuringElement / 2, static_cast<int>(inputWaveform.size())));
 
     // Initialize min and max elements
     std::pair<typename Waveform<T>::const_iterator, typename Waveform<T>::const_iterator>

--- a/larreco/HitFinder/HitFinderTools/WaveformTools_tool.cc
+++ b/larreco/HitFinder/HitFinderTools/WaveformTools_tool.cc
@@ -594,7 +594,7 @@ namespace reco_tool {
                                                           Waveform<T>& differenceVec) const
   {
     // Set the window size
-    int halfWindowSize(structuringElement / 2);
+    int halfWindowSize(std::min<int>(structuringElement / 2, static_cast<int>(inputWaveform.size())));
 
     // Initialize min and max elements
     std::pair<typename Waveform<T>::const_iterator, typename Waveform<T>::const_iterator>


### PR DESCRIPTION
halfWindowSize is now capped which prevents line 602 from reading off the end of the input waveform. This removes the issue with hit product sizes not being reproducible. 