### PR TITLE
pass maxTriplets to TripletFinder

### DIFF
--- a/larreco/SpacePointSolver/SpacePointSolver_module.cc
+++ b/larreco/SpacePointSolver/SpacePointSolver_module.cc
@@ -479,7 +479,8 @@ namespace reco3d {
                        {},
                        fDistThresh,
                        fDistThreshDrift,
-                       fXHitOffset);
+                       fXHitOffset,
+                       fMaxNTriplets);
       auto triplets = tf.TripletsTwoView();
       if (fMaxNTriplets > 0 && triplets.size() > fMaxNTriplets) {
         std::cout << "Huge Triplet Size, bailing out" << std::endl;
@@ -499,7 +500,8 @@ namespace reco3d {
                        vbadchans,
                        fDistThresh,
                        fDistThreshDrift,
-                       fXHitOffset);
+                       fXHitOffset,
+                       fMaxNTriplets);
       auto triplets = tf.Triplets();
       if (fMaxNTriplets > 0 && triplets.size() > fMaxNTriplets) {
         std::cout << "Huge Triplet Size, bailing out" << std::endl;

--- a/larreco/SpacePointSolver/TripletFinder.cxx
+++ b/larreco/SpacePointSolver/TripletFinder.cxx
@@ -18,11 +18,13 @@ namespace reco3d {
                                const std::vector<raw::ChannelID_t>& vbad,
                                double distThresh,
                                double distThreshDrift,
-                               double xhitOffset)
+                               double xhitOffset,
+                               int maxTriplets)
     : wireReadoutGeom{&art::ServiceHandle<geo::WireReadout const>()->Get()}
     , fDistThresh(distThresh)
     , fDistThreshDrift(distThreshDrift)
     , fXHitOffset(xhitOffset)
+    , fMaxTriplets(maxTriplets)
   {
     FillHitMap(detProp, xhits, fX_by_tpc);
     FillHitMap(detProp, uhits, fU_by_tpc);
@@ -169,6 +171,7 @@ namespace reco3d {
 
         // Loop through all those matching hits
         for (auto xvit = xvit_begin; xvit != xvs.end() && SameXHit(*xvit, xu); ++xvit) {
+          if (fMaxTriplets > 0 and nxuv > fMaxTriplets) break;
           const HitOrChan& v = xvit->b;
 
           // Only allow one bad channel per triplet
@@ -207,6 +210,7 @@ namespace reco3d {
 
           ret.emplace_back(HitTriplet{x.hit, u.hit, v.hit, pt});
           ++nxuv;
+          if (fMaxTriplets > 0 and nxuv > fMaxTriplets) break;
         } // end for xv
       }   // end for xu
 

--- a/larreco/SpacePointSolver/TripletFinder.h
+++ b/larreco/SpacePointSolver/TripletFinder.h
@@ -57,7 +57,8 @@ namespace reco3d {
                   const std::vector<raw::ChannelID_t>& vbad,
                   double distThresh,
                   double distThreshDrift,
-                  double xhitOffset);
+                  double xhitOffset,
+                  int maxTriplets = 0);
 
     std::vector<HitTriplet> Triplets();
     /// Only search for XU intersections
@@ -89,6 +90,7 @@ namespace reco3d {
     double fDistThresh;
     double fDistThreshDrift;
     double fXHitOffset;
+    int fMaxTriplets;
 
     std::map<geo::TPCID, std::vector<HitOrChan>> fX_by_tpc;
     std::map<geo::TPCID, std::vector<HitOrChan>> fU_by_tpc;


### PR DESCRIPTION
This PR moves the check about the maximum number of triplets upstream where the triplets are made instead of just counting them after the fact. Since the parameter fMaxNTriplets is set to zero by default this should not have effect on any current workflow.