### PR TITLE
safety check for debug version

### DIFF
--- a/larreco/RecoAlg/TrackMomentumCalculator.cxx
+++ b/larreco/RecoAlg/TrackMomentumCalculator.cxx
@@ -770,7 +770,7 @@ namespace trkf {
     if (startpoint < min_resolution) startpoint = (max_resolution - min_resolution) / 2.;
     bool fixresolution = false;
     double maxres = max_resolution;
-    if (max_resolution == 0 || max_resolution == min_resolution) {
+    if (max_resolution == 0 || max_resolution <= min_resolution) {
       fixresolution = true;
       startpoint = min_resolution;
       maxres += 1;

--- a/larreco/RecoAlg/TrackMomentumCalculator.cxx
+++ b/larreco/RecoAlg/TrackMomentumCalculator.cxx
@@ -485,15 +485,20 @@ namespace trkf {
     double startpoint = 2;
     if (startpoint < min_resolution)
       startpoint = (max_resolution - min_resolution) / 2.; // prevent wrong values
-    if (max_resolution == 0) startpoint = min_resolution;
+    bool fixresolution = false;
+    double maxres = max_resolution;
+    if (max_resolution == 0 || max_resolution == min_resolution) {
+      fixresolution = true;
+      startpoint = min_resolution;
+      maxres += 1;
+    }
 
     // Starting energy as double of the energy by range
     // Assumes that the smallet possible energy is given by 60%  with CSDA
     // Step as 10 %
     mP.SetLimitedVariable(0, "p_{MCS}", minP * 2, minP * 0.1, minP * 0.6, maxMomentum_MeV / 1.e3);
-    mP.SetLimitedVariable(
-      1, "#delta#theta", startpoint, startpoint / 2., min_resolution, max_resolution);
-    if (max_resolution == 0) { mP.FixVariable(1); }
+    mP.SetLimitedVariable(1, "#delta#theta", startpoint, startpoint / 2., min_resolution, maxres);
+    if (fixresolution) { mP.FixVariable(1); }
     mP.SetMaxFunctionCalls(1.E9);
     mP.SetMaxIterations(1.E9);
     mP.SetTolerance(0.01);
@@ -763,13 +768,18 @@ namespace trkf {
     // Start point for resolution
     double startpoint = 2;
     if (startpoint < min_resolution) startpoint = (max_resolution - min_resolution) / 2.;
-    if (max_resolution == 0) startpoint = min_resolution;
+    bool fixresolution = false;
+    double maxres = max_resolution;
+    if (max_resolution == 0 || max_resolution == min_resolution) {
+      fixresolution = true;
+      startpoint = min_resolution;
+      maxres += 1;
+    }
 
     mP.SetFunction(FCA);
     mP.SetLimitedVariable(0, "p_{MCS}", 1.0, 0.01, 0.001, maxMomentum_MeV / 1.e3);
-    mP.SetLimitedVariable(
-      1, "#delta#theta", startpoint, startpoint / 2., min_resolution, max_resolution);
-    if (max_resolution == 0) { mP.FixVariable(1); }
+    mP.SetLimitedVariable(1, "#delta#theta", startpoint, startpoint / 2., min_resolution, maxres);
+    if (fixresolution) { mP.FixVariable(1); }
     mP.SetMaxFunctionCalls(1.E9);
     mP.SetMaxIterations(1.E9);
     mP.SetTolerance(0.01);

--- a/larreco/RecoAlg/TrackMomentumCalculator.cxx
+++ b/larreco/RecoAlg/TrackMomentumCalculator.cxx
@@ -487,7 +487,7 @@ namespace trkf {
       startpoint = (max_resolution - min_resolution) / 2.; // prevent wrong values
     bool fixresolution = false;
     double maxres = max_resolution;
-    if (max_resolution == 0 || max_resolution == min_resolution) {
+    if (max_resolution == 0 || max_resolution <= min_resolution) {
       fixresolution = true;
       startpoint = min_resolution;
       maxres += 1;


### PR DESCRIPTION
Code works fine, however, while running with "debug" quals, I got the following error:
```
Begin processing the 1st record. run: 1497 subRun: 1 event: 25201 at 27-Feb-2025 04:44:58 CST
lar: /scratch/workspace/critic-slf/BUILDTYPE/debug/QUAL/e26/label1/swarm/label2/SLF7/build/root/v6_28_12/source/root-6.28.12/math/minuit2/src/MnUserTransformation.cxx:358: void ROOT::Minuit2::MnUserTransformation::SetLimits(unsigned int, double, double): Assertion `low != up' failed
```
Looking at `/cvmfs/larsoft.opensciencegrid.org/products/root/v6_28_12/source/root-6.28.12/math/minuit2/src/MnUserTransformation.cxx:358`, the following check is done:
```
void MnUserTransformation::SetLimits(unsigned int n, double low, double up)
{
   // set limits (lower/upper) for parameter n (external index)
   assert(n < fParameters.size());
   assert(low != up);
   fParameters[n].SetLimits(low, up);
}
```
