### PR TITLE
using new anab::Calorimetry with E-field and phi info

### DIFF
--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -408,8 +408,8 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
                                                 Phis));
       }
       else {
-        outputCalo->push_back(
-          anab::Calorimetry(util::kBogusD, {}, {}, {}, {}, util::kBogusD, {}, {}, {}, plane, {}, {}));
+        outputCalo->push_back(anab::Calorimetry(
+          util::kBogusD, {}, {}, {}, {}, util::kBogusD, {}, {}, {}, plane, {}, {}));
       }
 
       util::CreateAssn(evt, *outputCalo, tracklist[trk_i], *outputCaloAssn);

--- a/larreco/Calorimetry/GnocchiCalorimetry_module.cc
+++ b/larreco/Calorimetry/GnocchiCalorimetry_module.cc
@@ -275,6 +275,8 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
       std::vector<geo::Point_t> xyzs;
       std::vector<size_t> tp_indices;
       geo::PlaneID plane;
+      std::vector<float> Efields;
+      std::vector<float> Phis;
 
       // setup the plane ID
       plane.Plane = plane_i;
@@ -348,6 +350,8 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
         pitches.push_back(pitch);
         xyzs.push_back(location);
         kinetic_energy += dEdx * pitch;
+        Efields.push_back(EField);
+        Phis.push_back(phi);
 
         // TODO: FIXME
         // It seems weird that the "trajectory-point-index" actually is the
@@ -399,11 +403,13 @@ void calo::GnocchiCalorimetry::produce(art::Event& evt)
                                                 pitches,
                                                 xyzs,
                                                 tp_indices,
-                                                plane));
+                                                plane,
+                                                Efields,
+                                                Phis));
       }
       else {
         outputCalo->push_back(
-          anab::Calorimetry(util::kBogusD, {}, {}, {}, {}, util::kBogusD, {}, {}, {}, plane));
+          anab::Calorimetry(util::kBogusD, {}, {}, {}, {}, util::kBogusD, {}, {}, {}, plane, {}, {}));
       }
 
       util::CreateAssn(evt, *outputCalo, tracklist[trk_i], *outputCaloAssn);


### PR DESCRIPTION
Using new anab::Calorimetry with more hit info for `larreco/Calorimetry/GnocchiCalorimetry_module.cc`.
Relavent pull request in lardataobj: [link](https://github.com/LArSoft/lardataobj/pull/52)

- Efield: E-field strength for a hit that is used for calorimetry based on recombination models.
- Phi: angle between track direction at a hit and E-field that is used for calorimetry based on angle dependent recombination models.

Adding these two values are essential for shifting recombination parameters and TPC gain calibration constant on flight at analysis level. This will make detector systematic studies much simpler.