### PR TITLE
Remove use of art's `art::Event::getView`

### DIFF
--- a/larreco/EventFinder/EventCheater_module.cc
+++ b/larreco/EventFinder/EventCheater_module.cc
@@ -22,7 +22,6 @@
 #include "art/Framework/Core/ModuleMacros.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
-#include "art/Framework/Principal/View.h"
 #include "canvas/Persistency/Common/FindManyP.h"
 #include "canvas/Persistency/Common/FindOneP.h"
 #include "fhiclcpp/ParameterSet.h"
@@ -58,17 +57,15 @@ namespace event {
   //--------------------------------------------------------------------
   void EventCheater::produce(art::Event& evt)
   {
-
-    art::View<simb::MCParticle> pcol;
-    evt.getView(fG4ModuleLabel, pcol);
+    auto const pcol = evt.getHandle<std::vector<simb::MCParticle>>(fG4ModuleLabel);
 
     art::FindOneP<simb::MCTruth> fo(pcol, evt, fG4ModuleLabel);
 
     // make a map of the track id for each sim::Particle to its entry in the
     // collection of sim::Particles
     std::map<int, int> trackIDToPColEntry;
-    for (size_t p = 0; p < pcol.vals().size(); ++p)
-      trackIDToPColEntry[pcol.vals().at(p)->TrackId()] = p;
+    for (size_t p = 0; p < pcol->size(); ++p)
+      trackIDToPColEntry[(*pcol)[p].TrackId()] = p;
 
     // grab the vertices that have been reconstructed
     art::Handle<std::vector<recob::Vertex>> vertexcol;

--- a/larreco/RecoAlg/ClusterMatchAlg.cxx
+++ b/larreco/RecoAlg/ClusterMatchAlg.cxx
@@ -200,33 +200,27 @@ namespace cluster {
   {
     if (!_ModName_MCTruth.size()) return;
 
-    std::vector<const simb::MCTruth*> mciArray;
+    auto mcis = evt.getHandle<std::vector<simb::MCTruth>>(_ModName_MCTruth);
+    if (!mcis) { return; }
 
-    try {
-
-      evt.getView(_ModName_MCTruth, mciArray);
-    }
-    catch (art::Exception const& e) {
-
-      if (e.categoryCode() != art::errors::ProductNotFound) throw;
-    }
-
-    for (size_t i = 0; i < mciArray.size(); ++i) {
+    // FIXME: The below algorithm is very complicated for only wanting to access the first
+    // element of a collection.
+    for (size_t i = 0; i < mcis->size(); ++i) {
 
       if (i == 1) {
         mf::LogWarning("ClusterMatchAlg") << " Ignoring > 2nd MCTruth in MC generator...";
         break;
       }
-      const simb::MCTruth* mci_ptr(mciArray.at(i));
+      const simb::MCTruth& mci = (*mcis)[i];
 
-      for (size_t j = 0; j < (size_t)(mci_ptr->NParticles()); ++j) {
+      for (size_t j = 0; j < (size_t)(mci.NParticles()); ++j) {
 
         if (j == 1) {
           mf::LogWarning("ClusterMatchAlg") << " Ignoring > 2nd MCParticle in MC generator...";
           break;
         }
 
-        const simb::MCParticle part(mci_ptr->GetParticle(j));
+        const simb::MCParticle part(mci.GetParticle(j));
 
         _pdgid = part.PdgCode();
         _mc_E = part.E();

--- a/larreco/TrackFinder/CCTrackMaker_module.cc
+++ b/larreco/TrackFinder/CCTrackMaker_module.cc
@@ -1911,7 +1911,7 @@ namespace trkf {
     // (https://bugs.llvm.org/show_bug.cgi?id=21629)
     newtrk.EndInTPC = {{false, false}};
     newtrk.GoodEnd = {{false, false}};
-    newtrk.DtrID = {0};
+    newtrk.DtrID = std::vector<short>{0};
     newtrk.PDGCode = -1;
 
     unsigned short icl, iht;


### PR DESCRIPTION
All instances of `art::Event::getView(...)` are unnecessary as only data products of the type `std::vector<T>`s are retrieved when `getView(...)` is called.  Because the Phlex framework will not support the equivalent of art views, this PR removes their unnecessary use.