### PR TITLE
Updating the space point builder to match the version currently in use by SBN experiments

### DIFF
--- a/larreco/ClusterFinder/Cluster3D_module.cc
+++ b/larreco/ClusterFinder/Cluster3D_module.cc
@@ -45,8 +45,8 @@
 
 // Framework Includes
 #include "art/Framework/Core/EDProducer.h"
-#include "art/Framework/Principal/Event.h"
 #include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
 #include "art/Persistency/Common/PtrMaker.h"
 #include "art/Utilities/make_tool.h"
 #include "art_root_io/TFileService.h"
@@ -133,13 +133,18 @@ namespace lar_cluster3d {
         , artPathEdgeVector(std::make_unique<std::vector<recob::Edge>>())
         , artVertexEdgeVector(std::make_unique<std::vector<recob::Edge>>())
         , artClusterAssociations(std::make_unique<art::Assns<recob::Cluster, recob::Hit>>())
-        , artPFPartAxisAssociations(std::make_unique<art::Assns<recob::PFParticle, recob::PCAxis>>())
-        , artPFPartClusAssociations(std::make_unique<art::Assns<recob::PFParticle, recob::Cluster>>())
-        , artPFPartSPAssociations(std::make_unique<art::Assns<recob::SpacePoint, recob::PFParticle>>())
-        , artPFPartPPAssociations(std::make_unique<art::Assns<recob::SpacePoint, recob::PFParticle>>())
+        , artPFPartAxisAssociations(
+            std::make_unique<art::Assns<recob::PFParticle, recob::PCAxis>>())
+        , artPFPartClusAssociations(
+            std::make_unique<art::Assns<recob::PFParticle, recob::Cluster>>())
+        , artPFPartSPAssociations(
+            std::make_unique<art::Assns<recob::SpacePoint, recob::PFParticle>>())
+        , artPFPartPPAssociations(
+            std::make_unique<art::Assns<recob::SpacePoint, recob::PFParticle>>())
         , artPFPartSeedAssociations(std::make_unique<art::Assns<recob::PFParticle, recob::Seed>>())
         , artPFPartEdgeAssociations(std::make_unique<art::Assns<recob::Edge, recob::PFParticle>>())
-        , artPFPartPathEdgeAssociations(std::make_unique<art::Assns<recob::Edge, recob::PFParticle>>())
+        , artPFPartPathEdgeAssociations(
+            std::make_unique<art::Assns<recob::Edge, recob::PFParticle>>())
         , artSeedHitAssociations(std::make_unique<art::Assns<recob::Seed, recob::Hit>>())
         , artPPHitAssociations(std::make_unique<art::Assns<recob::Hit, recob::SpacePoint>>())
         , artEdgeSPAssociations(std::make_unique<art::Assns<recob::SpacePoint, recob::Edge>>())
@@ -154,24 +159,21 @@ namespace lar_cluster3d {
         , fExtremeName(extremeName)
       {}
 
-      void
-      makeClusterHitAssns(RecobHitVector& recobHits)
+      void makeClusterHitAssns(RecobHitVector& recobHits)
       {
         util::CreateAssn(fEvt, *artClusterVector, recobHits, *artClusterAssociations);
       }
 
-      void
-      makeSpacePointHitAssns(std::vector<recob::SpacePoint>& spacePointVector,
-                             RecobHitVector& recobHits,
-                             art::Assns<recob::Hit, recob::SpacePoint>& spHitAssns,
-                             const std::string& path = "")
+      void makeSpacePointHitAssns(std::vector<recob::SpacePoint>& spacePointVector,
+                                  RecobHitVector& recobHits,
+                                  art::Assns<recob::Hit, recob::SpacePoint>& spHitAssns,
+                                  const std::string& path = "")
       {
         for (auto& hit : recobHits)
           util::CreateAssn(fEvt, spacePointVector, hit, spHitAssns, path);
       }
 
-      void
-      makePFPartPCAAssns()
+      void makePFPartPCAAssns()
       {
         util::CreateAssn(fEvt,
                          *artPFParticleVector,
@@ -181,8 +183,7 @@ namespace lar_cluster3d {
                          artPCAxisVector->size());
       }
 
-      void
-      makePFPartSeedAssns(size_t numSeedsStart)
+      void makePFPartSeedAssns(size_t numSeedsStart)
       {
         util::CreateAssn(fEvt,
                          *artPFParticleVector,
@@ -192,8 +193,7 @@ namespace lar_cluster3d {
                          artSeedVector->size());
       }
 
-      void
-      makePFPartClusterAssns(size_t clusterStart)
+      void makePFPartClusterAssns(size_t clusterStart)
       {
         util::CreateAssn(fEvt,
                          *artPFParticleVector,
@@ -203,8 +203,7 @@ namespace lar_cluster3d {
                          artClusterVector->size());
       }
 
-      void
-      makePFPartSpacePointAssns(
+      void makePFPartSpacePointAssns(
         std::vector<recob::SpacePoint>& spacePointVector,
         art::Assns<recob::SpacePoint, recob::PFParticle>& pfPartSPAssociations,
         size_t spacePointStart,
@@ -216,11 +215,10 @@ namespace lar_cluster3d {
         }
       }
 
-      void
-      makePFPartEdgeAssns(std::vector<recob::Edge>& edgeVector,
-                          art::Assns<recob::Edge, recob::PFParticle>& pfPartEdgeAssociations,
-                          size_t edgeStart,
-                          const std::string& instance = "")
+      void makePFPartEdgeAssns(std::vector<recob::Edge>& edgeVector,
+                               art::Assns<recob::Edge, recob::PFParticle>& pfPartEdgeAssociations,
+                               size_t edgeStart,
+                               const std::string& instance = "")
       {
         for (size_t idx = edgeStart; idx < edgeVector.size(); idx++) {
           art::Ptr<recob::Edge> edge = makeEdgePtr(idx, instance);
@@ -229,23 +227,21 @@ namespace lar_cluster3d {
         }
       }
 
-      void
-      makeEdgeSpacePointAssns(std::vector<recob::Edge>& edgeVector,
-                              RecobSpacePointVector& spacePointVector,
-                              art::Assns<recob::SpacePoint, recob::Edge>& edgeSPAssociations,
-                              const std::string& path = "")
+      void makeEdgeSpacePointAssns(std::vector<recob::Edge>& edgeVector,
+                                   RecobSpacePointVector& spacePointVector,
+                                   art::Assns<recob::SpacePoint, recob::Edge>& edgeSPAssociations,
+                                   const std::string& path = "")
       {
         for (auto& spacePoint : spacePointVector)
           util::CreateAssn(fEvt, edgeVector, spacePoint, edgeSPAssociations, path);
       }
 
-      void
-      outputObjects(bool spacePointsOnly)
+      void outputObjects(bool spacePointsOnly)
       {
         fEvt.put(std::move(artSpacePointVector));
         fEvt.put(std::move(artSPHitAssociations));
 
-//        if (!spacePointsOnly)
+        //        if (!spacePointsOnly)
         {
           fEvt.put(std::move(artPCAxisVector));
           fEvt.put(std::move(artPFParticleVector));
@@ -272,15 +268,13 @@ namespace lar_cluster3d {
         }
       }
 
-      art::Ptr<recob::SpacePoint>
-      makeSpacePointPtr(size_t index, const std::string& instance = "")
+      art::Ptr<recob::SpacePoint> makeSpacePointPtr(size_t index, const std::string& instance = "")
       {
         if (empty(instance)) { return fSPPtrMaker(index); }
         return fSPPtrMakerPath(index);
       };
 
-      art::Ptr<recob::Edge>
-      makeEdgePtr(size_t index, const std::string& instance = "")
+      art::Ptr<recob::Edge> makeEdgePtr(size_t index, const std::string& instance = "")
       {
         if (empty(instance)) { return fEdgePtrMaker(index); }
         return fEdgePtrMakerPath(index);
@@ -470,8 +464,7 @@ namespace lar_cluster3d {
      *
      *  @param pca  The Principal Components Analysis parameters for the cluster
      */
-    bool
-    aParallelHitsCluster(const reco::PrincipalComponents& pca) const
+    bool aParallelHitsCluster(const reco::PrincipalComponents& pca) const
     {
       return fabs(pca.getEigenVectors().row(2)(0)) > m_parallelHitsCosAng &&
              3. * sqrt(pca.getEigenValues()(1)) > m_parallelHitsTransWid;
@@ -574,7 +567,7 @@ namespace lar_cluster3d {
     produces<art::Assns<recob::Hit, recob::SpacePoint>>();
 
     // Do we output anything else?
-//    if (!m_onlyMakSpacePoints)
+    //    if (!m_onlyMakSpacePoints)
     {
       produces<std::vector<recob::PCAxis>>();
       produces<std::vector<recob::PFParticle>>();
@@ -608,8 +601,7 @@ namespace lar_cluster3d {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void
-  Cluster3D::beginJob()
+  void Cluster3D::beginJob()
   {
     /**
      *  @brief beginJob will be tasked with initializing monitoring, in necessary, but also to init the
@@ -620,12 +612,11 @@ namespace lar_cluster3d {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void
-  Cluster3D::produce(art::Event& evt)
+  void Cluster3D::produce(art::Event& evt)
   {
     mf::LogInfo("Cluster3D") << " *** Cluster3D::produce(...)  [Run=" << evt.run()
-                                << ", Event=" << evt.id().event() << "] Starting Now! *** "
-                                << std::endl;
+                             << ", Event=" << evt.id().event() << "] Starting Now! *** "
+                             << std::endl;
 
     // Set up for monitoring the timing... at some point this should be removed in favor of
     // external profilers
@@ -640,14 +631,14 @@ namespace lar_cluster3d {
     // Get instances of the primary data structures needed
     reco::ClusterParametersList clusterParametersList;
     IHit3DBuilder::RecobHitToPtrMap clusterHitToArtPtrMap;
-    std::unique_ptr<reco::HitPairList> hitPairList(new reco::HitPairList); // Potentially lots of hits, use heap instead of stack
+    std::unique_ptr<reco::HitPairList> hitPairList(
+      new reco::HitPairList); // Potentially lots of hits, use heap instead of stack
 
     // Call the algorithm that builds 3D hits and stores the hit collection
     m_hit3DBuilderAlg->Hit3DBuilder(evt, *hitPairList, clusterHitToArtPtrMap);
 
     // Only do the rest if we are not in the mode of only building space points (requested by ML folks)
-    if (!m_onlyMakSpacePoints) 
-    {
+    if (!m_onlyMakSpacePoints) {
       // Call the main workhorse algorithm for building the local version of candidate 3D clusters
       m_clusterAlg->Cluster3DHits(*hitPairList, clusterParametersList);
 
@@ -665,11 +656,12 @@ namespace lar_cluster3d {
     // Call the module that does the end processing (of which there is quite a bit of work!)
     // This goes here to insure that something is always written to the data store
     auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
     util::GeometryUtilities const gser{*lar::providerFrom<geo::Geometry>(),
-                                        art::ServiceHandle<geo::WireReadout>()->Get(),
-                                        clockData,
-                                        detProp};
+                                       art::ServiceHandle<geo::WireReadout>()->Get(),
+                                       clockData,
+                                       detProp};
 
     ProduceArtClusters(gser, output, *hitPairList, clusterParametersList, clusterHitToArtPtrMap);
 
@@ -689,8 +681,7 @@ namespace lar_cluster3d {
       m_artHitsTime = m_hit3DBuilderAlg->getTimeToExecute(IHit3DBuilder::COLLECTARTHITS);
       m_makeHitsTime = m_hit3DBuilderAlg->getTimeToExecute(IHit3DBuilder::BUILDTHREEDHITS);
 
-      if (!m_onlyMakSpacePoints)
-      {
+      if (!m_onlyMakSpacePoints) {
         m_buildNeighborhoodTime = m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDHITTOHITMAP);
         m_dbscanTime = m_clusterAlg->getTimeToExecute(IClusterAlg::RUNDBSCAN) +
                        m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDCLUSTERINFO);
@@ -705,12 +696,12 @@ namespace lar_cluster3d {
       m_pRecoTree->Fill();
 
       mf::LogDebug("Cluster3D") << "*** Cluster3D total time: " << m_totalTime
-                                   << ", art: " << m_artHitsTime << ", make: " << m_makeHitsTime
-                                   << ", build: " << m_buildNeighborhoodTime
-                                   << ", clustering: " << m_dbscanTime
-                                   << ", merge: " << m_clusterMergeTime
-                                   << ", path: " << m_pathFindingTime << ", finish: " << m_finishTime
-                                   << std::endl;
+                                << ", art: " << m_artHitsTime << ", make: " << m_makeHitsTime
+                                << ", build: " << m_buildNeighborhoodTime
+                                << ", clustering: " << m_dbscanTime
+                                << ", merge: " << m_clusterMergeTime
+                                << ", path: " << m_pathFindingTime << ", finish: " << m_finishTime
+                                << std::endl;
     }
 
     // Will we ever get here? ;-)
@@ -719,8 +710,7 @@ namespace lar_cluster3d {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void
-  Cluster3D::InitializeMonitoring()
+  void Cluster3D::InitializeMonitoring()
   {
     art::ServiceHandle<art::TFileService> tfs;
     m_pRecoTree = tfs->make<TTree>("monitoring", "LAr Reco");
@@ -742,8 +732,7 @@ namespace lar_cluster3d {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void
-  Cluster3D::PrepareEvent(const art::Event& evt)
+  void Cluster3D::PrepareEvent(const art::Event& evt)
   {
     m_run = evt.run();
     m_event = evt.id().event();
@@ -760,12 +749,11 @@ namespace lar_cluster3d {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void
-  Cluster3D::findTrackSeeds(art::Event& evt,
-                                  reco::ClusterParameters& cluster,
-                                  IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
-                                  std::vector<recob::Seed>& seedVec,
-                                  art::Assns<recob::Seed, recob::Hit>& seedHitAssns) const
+  void Cluster3D::findTrackSeeds(art::Event& evt,
+                                 reco::ClusterParameters& cluster,
+                                 IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
+                                 std::vector<recob::Seed>& seedVec,
+                                 art::Assns<recob::Seed, recob::Hit>& seedHitAssns) const
   {
     /**
      *  @brief This method provides an interface to various algorithms for finding candiate
@@ -847,17 +835,15 @@ namespace lar_cluster3d {
   }
 
   struct Hit3DDistanceOrder {
-    bool
-    operator()(const std::pair<float, const reco::ClusterHit3D*>& left,
-               const std::pair<float, const reco::ClusterHit3D*>& right)
+    bool operator()(const std::pair<float, const reco::ClusterHit3D*>& left,
+                    const std::pair<float, const reco::ClusterHit3D*>& right)
     {
       return left.first < right.first;
     }
   };
 
-  void
-  Cluster3D::splitClustersWithMST(reco::ClusterParameters& clusterParameters,
-                                        reco::ClusterParametersList& clusterParametersList) const
+  void Cluster3D::splitClustersWithMST(reco::ClusterParameters& clusterParameters,
+                                       reco::ClusterParametersList& clusterParametersList) const
   {
     // This is being left in place for future development. Essentially, it was an attempt to implement
     // a Minimum Spanning Tree as a way to split a particular cluster topology, one where two straight
@@ -882,8 +868,7 @@ namespace lar_cluster3d {
     typedef std::list<DistanceEdgePair> DistanceEdgePairList;
 
     struct DistanceEdgePairOrder {
-      bool
-      operator()(const DistanceEdgePair& left, const DistanceEdgePair& right) const
+      bool operator()(const DistanceEdgePair& left, const DistanceEdgePair& right) const
       {
         return left.first > right.first;
       }
@@ -1033,8 +1018,7 @@ namespace lar_cluster3d {
   public:
     CopyIfInRange(float maxRange) : m_maxRange(maxRange) {}
 
-    bool
-    operator()(const reco::ClusterHit3D* hit3D) const
+    bool operator()(const reco::ClusterHit3D* hit3D) const
     {
       return hit3D->getDocaToAxis() < m_maxRange;
     }
@@ -1043,9 +1027,8 @@ namespace lar_cluster3d {
     float m_maxRange;
   };
 
-  void
-  Cluster3D::splitClustersWithHough(reco::ClusterParameters& clusterParameters,
-                                          reco::ClusterParametersList& clusterParametersList) const
+  void Cluster3D::splitClustersWithHough(reco::ClusterParameters& clusterParameters,
+                                         reco::ClusterParametersList& clusterParametersList) const
   {
     // @brief A method for splitted "crossed tracks" clusters into separate clusters
     //
@@ -1187,12 +1170,11 @@ namespace lar_cluster3d {
     }
   }
 
-  void
-  Cluster3D::ProduceArtClusters(util::GeometryUtilities const& gser,
-                                      ArtOutputHandler& output,
-                                      reco::HitPairList& hitPairVector,
-                                      reco::ClusterParametersList& clusterParametersList,
-                                      IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap) const
+  void Cluster3D::ProduceArtClusters(util::GeometryUtilities const& gser,
+                                     ArtOutputHandler& output,
+                                     reco::HitPairList& hitPairVector,
+                                     reco::ClusterParametersList& clusterParametersList,
+                                     IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap) const
   {
     /**
      *  @brief The workhorse to take the candidate 3D clusters and produce all of the necessary art output
@@ -1364,49 +1346,48 @@ namespace lar_cluster3d {
       }
     }
 
-    mf::LogDebug("Cluster3D") << "--> Preparing to save the remaining space points, there are " << hitPairVector.size() << std::endl;
+    mf::LogDebug("Cluster3D") << "--> Preparing to save the remaining space points, there are "
+                              << hitPairVector.size() << std::endl;
 
     // Right now error matrix is uniform...
     int nFreePoints(0);
 
     // Run through the HitPairVector and add any unused hit pairs to the list
-    for (auto& hitPair : hitPairVector) 
-    {
-        if (hitPair.bitsAreSet(reco::ClusterHit3D::MADESPACEPOINT)) continue;
+    for (auto& hitPair : hitPairVector) {
+      if (hitPair.bitsAreSet(reco::ClusterHit3D::MADESPACEPOINT)) continue;
 
-        double spacePointPos[] = {
-          hitPair.getPosition()[0], hitPair.getPosition()[1], hitPair.getPosition()[2]};
-        double spacePointErr[] = {1., 0., 0., 1., 0., 1.};
-        double chisq = hitPair.getHitChiSquare();
+      double spacePointPos[] = {
+        hitPair.getPosition()[0], hitPair.getPosition()[1], hitPair.getPosition()[2]};
+      double spacePointErr[] = {1., 0., 0., 1., 0., 1.};
+      double chisq = hitPair.getHitChiSquare();
 
-        RecobHitVector recobHits;
+      RecobHitVector recobHits;
 
-        for (const auto hit : hitPair.getHits()) {
-          if (!hit) continue;
+      for (const auto hit : hitPair.getHits()) {
+        if (!hit) continue;
 
-          art::Ptr<recob::Hit> hitPtr = hitToPtrMap[hit->getHit()];
-          recobHits.push_back(hitPtr);
-        }
+        art::Ptr<recob::Hit> hitPtr = hitToPtrMap[hit->getHit()];
+        recobHits.push_back(hitPtr);
+      }
 
-        nFreePoints++;
+      nFreePoints++;
 
-        spacePointErr[1] = hitPair.getTotalCharge();
-        spacePointErr[3] = hitPair.getChargeAsymmetry();
+      spacePointErr[1] = hitPair.getTotalCharge();
+      spacePointErr[3] = hitPair.getChargeAsymmetry();
 
-        output.artSpacePointVector->push_back(
-          recob::SpacePoint(spacePointPos, spacePointErr, chisq, output.artSpacePointVector->size()));
+      output.artSpacePointVector->push_back(
+        recob::SpacePoint(spacePointPos, spacePointErr, chisq, output.artSpacePointVector->size()));
 
-        if (!recobHits.empty())
-          output.makeSpacePointHitAssns(
-            *output.artSpacePointVector.get(), recobHits, *output.artSPHitAssociations.get());
-    } 
+      if (!recobHits.empty())
+        output.makeSpacePointHitAssns(
+          *output.artSpacePointVector.get(), recobHits, *output.artSPHitAssociations.get());
+    }
 
     mf::LogDebug("Cluster3D") << "++++>>>> total num hits: " << hitPairVector.size()
-              << ", num free: " << nFreePoints;
+                              << ", num free: " << nFreePoints;
   }
 
-  size_t
-  Cluster3D::countUltimateDaughters(reco::ClusterParameters& clusterParameters) const
+  size_t Cluster3D::countUltimateDaughters(reco::ClusterParameters& clusterParameters) const
   {
     size_t localCount(0);
 
@@ -1420,15 +1401,14 @@ namespace lar_cluster3d {
     return localCount;
   }
 
-  size_t
-  Cluster3D::FindAndStoreDaughters(util::GeometryUtilities const& gser,
-                                         ArtOutputHandler& output,
-                                         reco::ClusterParameters& clusterParameters,
-                                         size_t pfParticleParent,
-                                         IdxToPCAMap& idxToPCAMap,
-                                         IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
-                                         Hit3DToSPPtrMap& hit3DToSPPtrMap,
-                                         Hit3DToSPPtrMap& best3DToSPPtrMap) const
+  size_t Cluster3D::FindAndStoreDaughters(util::GeometryUtilities const& gser,
+                                          ArtOutputHandler& output,
+                                          reco::ClusterParameters& clusterParameters,
+                                          size_t pfParticleParent,
+                                          IdxToPCAMap& idxToPCAMap,
+                                          IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
+                                          Hit3DToSPPtrMap& hit3DToSPPtrMap,
+                                          Hit3DToSPPtrMap& best3DToSPPtrMap) const
   {
     // This is a recursive routine, we keep calling ourself as long as the daughter list is non empty
     if (!clusterParameters.daughterList().empty()) {
@@ -1458,14 +1438,13 @@ namespace lar_cluster3d {
     return idxToPCAMap.size();
   }
 
-  size_t
-  Cluster3D::ConvertToArtOutput(util::GeometryUtilities const& gser,
-                                      ArtOutputHandler& output,
-                                      reco::ClusterParameters& clusterParameters,
-                                      size_t pfParticleParent,
-                                      IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
-                                      Hit3DToSPPtrMap& hit3DToSPPtrMap,
-                                      Hit3DToSPPtrMap& best3DToSPPtrMap) const
+  size_t Cluster3D::ConvertToArtOutput(util::GeometryUtilities const& gser,
+                                       ArtOutputHandler& output,
+                                       reco::ClusterParameters& clusterParameters,
+                                       size_t pfParticleParent,
+                                       IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
+                                       Hit3DToSPPtrMap& hit3DToSPPtrMap,
+                                       Hit3DToSPPtrMap& best3DToSPPtrMap) const
   {
     // prepare the algorithm to compute the cluster characteristics;
     // we use the "standard" one here, except that we override selected items
@@ -1680,14 +1659,13 @@ namespace lar_cluster3d {
     return pfParticleIdx;
   }
 
-  void
-  Cluster3D::MakeAndSaveSpacePoints(ArtOutputHandler& output,
-                                          std::vector<recob::SpacePoint>& spacePointVec,
-                                          art::Assns<recob::Hit, recob::SpacePoint>& spHitAssns,
-                                          reco::HitPairListPtr& clusHitPairVector,
-                                          IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
-                                          Hit3DToSPPtrMap& hit3DToSPPtrMap,
-                                          const std::string& instance) const
+  void Cluster3D::MakeAndSaveSpacePoints(ArtOutputHandler& output,
+                                         std::vector<recob::SpacePoint>& spacePointVec,
+                                         art::Assns<recob::Hit, recob::SpacePoint>& spHitAssns,
+                                         reco::HitPairListPtr& clusHitPairVector,
+                                         IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
+                                         Hit3DToSPPtrMap& hit3DToSPPtrMap,
+                                         const std::string& instance) const
   {
     // Reserve space...
     spacePointVec.reserve(spacePointVec.size() + clusHitPairVector.size());
@@ -1738,9 +1716,8 @@ namespace lar_cluster3d {
     return;
   }
 
-  void
-  Cluster3D::MakeAndSaveKinkPoints(ArtOutputHandler& output,
-                                         reco::ConvexHullKinkTupleList& kinkTupleVec) const
+  void Cluster3D::MakeAndSaveKinkPoints(ArtOutputHandler& output,
+                                        reco::ConvexHullKinkTupleList& kinkTupleVec) const
   {
     // Right now error matrix is uniform...
     double spError[] = {1., 0., 1., 0., 0., 1.};
@@ -1765,10 +1742,9 @@ namespace lar_cluster3d {
     return;
   }
 
-  void
-  Cluster3D::MakeAndSaveVertexPoints(ArtOutputHandler& output,
-                                           dcel2d::VertexList& vertexList,
-                                           dcel2d::HalfEdgeList& halfEdgeList) const
+  void Cluster3D::MakeAndSaveVertexPoints(ArtOutputHandler& output,
+                                          dcel2d::VertexList& vertexList,
+                                          dcel2d::HalfEdgeList& halfEdgeList) const
   {
     // We actually do two things here:
     // 1) Create space points to represent the vertex locations of the voronoi diagram
@@ -1831,10 +1807,9 @@ namespace lar_cluster3d {
     return;
   }
 
-  void
-  Cluster3D::MakeAndSavePCAPoints(ArtOutputHandler& output,
-                                        const reco::PrincipalComponents& fullPCA,
-                                        IdxToPCAMap& idxToPCAMap) const
+  void Cluster3D::MakeAndSavePCAPoints(ArtOutputHandler& output,
+                                       const reco::PrincipalComponents& fullPCA,
+                                       IdxToPCAMap& idxToPCAMap) const
   {
     // We actually do two things here:
     // 1) Create space points from the centroids of the PCA for each cluster

--- a/larreco/ClusterFinder/Cluster3D_module.cc
+++ b/larreco/ClusterFinder/Cluster3D_module.cc
@@ -574,7 +574,7 @@ namespace lar_cluster3d {
     produces<art::Assns<recob::Hit, recob::SpacePoint>>();
 
     // Do we output anything else?
-    if (!m_onlyMakSpacePoints)
+//    if (!m_onlyMakSpacePoints)
     {
       produces<std::vector<recob::PCAxis>>();
       produces<std::vector<recob::PFParticle>>();
@@ -657,8 +657,7 @@ namespace lar_cluster3d {
       // Run the path finding
       m_clusterPathAlg->ModifyClusters(clusterParametersList);
     }
-
-    if (m_enableMonitoring) theClockFinish.start();
+    // Otherwise we only have two data objects to output
 
     // Get the art ouput object
     ArtOutputHandler output(evt, m_pathInstance, m_vertexInstance, m_extremeInstance);
@@ -668,14 +667,16 @@ namespace lar_cluster3d {
     auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
     auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
     util::GeometryUtilities const gser{*lar::providerFrom<geo::Geometry>(),
-                                       art::ServiceHandle<geo::WireReadout>()->Get(),
-                                       clockData,
-                                       detProp};
+                                        art::ServiceHandle<geo::WireReadout>()->Get(),
+                                        clockData,
+                                        detProp};
 
     ProduceArtClusters(gser, output, *hitPairList, clusterParametersList, clusterHitToArtPtrMap);
 
     // Output to art
     output.outputObjects(m_onlyMakSpacePoints);
+
+    if (m_enableMonitoring) theClockFinish.start();
 
     // If monitoring then deal with the fallout
     if (m_enableMonitoring) {

--- a/larreco/ClusterFinder/Cluster3D_module.cc
+++ b/larreco/ClusterFinder/Cluster3D_module.cc
@@ -47,6 +47,7 @@
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Core/ModuleMacros.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art/Persistency/Common/PtrMaker.h"
 #include "art/Utilities/make_tool.h"
 #include "art_root_io/TFileService.h"
@@ -120,35 +121,30 @@ namespace lar_cluster3d {
                        std::string& pathName,
                        std::string& vertexName,
                        std::string& extremeName)
-        : artSpacePointVector(std::make_unique<std::vector<recob::SpacePoint>>())
-        , artSPHitAssociations(std::make_unique<art::Assns<recob::Hit, recob::SpacePoint>>())
-        , artPCAxisVector(std::make_unique<std::vector<recob::PCAxis>>())
-        , artPFParticleVector(std::make_unique<std::vector<recob::PFParticle>>())
-        , artClusterVector(std::make_unique<std::vector<recob::Cluster>>())
-        , artPathPointVector(std::make_unique<std::vector<recob::SpacePoint>>())
-        , artVertexPointVector(std::make_unique<std::vector<recob::SpacePoint>>())
-        , artExtremePointVector(std::make_unique<std::vector<recob::SpacePoint>>())
-        , artSeedVector(std::make_unique<std::vector<recob::Seed>>())
-        , artEdgeVector(std::make_unique<std::vector<recob::Edge>>())
-        , artPathEdgeVector(std::make_unique<std::vector<recob::Edge>>())
-        , artVertexEdgeVector(std::make_unique<std::vector<recob::Edge>>())
-        , artClusterAssociations(std::make_unique<art::Assns<recob::Cluster, recob::Hit>>())
-        , artPFPartAxisAssociations(
-            std::make_unique<art::Assns<recob::PFParticle, recob::PCAxis>>())
-        , artPFPartClusAssociations(
-            std::make_unique<art::Assns<recob::PFParticle, recob::Cluster>>())
-        , artPFPartSPAssociations(
-            std::make_unique<art::Assns<recob::SpacePoint, recob::PFParticle>>())
-        , artPFPartPPAssociations(
-            std::make_unique<art::Assns<recob::SpacePoint, recob::PFParticle>>())
-        , artPFPartSeedAssociations(std::make_unique<art::Assns<recob::PFParticle, recob::Seed>>())
-        , artPFPartEdgeAssociations(std::make_unique<art::Assns<recob::Edge, recob::PFParticle>>())
-        , artPFPartPathEdgeAssociations(
-            std::make_unique<art::Assns<recob::Edge, recob::PFParticle>>())
-        , artSeedHitAssociations(std::make_unique<art::Assns<recob::Seed, recob::Hit>>())
-        , artPPHitAssociations(std::make_unique<art::Assns<recob::Hit, recob::SpacePoint>>())
-        , artEdgeSPAssociations(std::make_unique<art::Assns<recob::SpacePoint, recob::Edge>>())
-        , artEdgePPAssociations(std::make_unique<art::Assns<recob::SpacePoint, recob::Edge>>())
+        : artPCAxisVector(new std::vector<recob::PCAxis>)
+        , artPFParticleVector(new std::vector<recob::PFParticle>)
+        , artClusterVector(new std::vector<recob::Cluster>)
+        , artSpacePointVector(new std::vector<recob::SpacePoint>)
+        , artPathPointVector(new std::vector<recob::SpacePoint>)
+        , artVertexPointVector(new std::vector<recob::SpacePoint>)
+        , artExtremePointVector(new std::vector<recob::SpacePoint>)
+        , artSeedVector(new std::vector<recob::Seed>)
+        , artEdgeVector(new std::vector<recob::Edge>)
+        , artPathEdgeVector(new std::vector<recob::Edge>)
+        , artVertexEdgeVector(new std::vector<recob::Edge>)
+        , artClusterAssociations(new art::Assns<recob::Cluster, recob::Hit>)
+        , artPFPartAxisAssociations(new art::Assns<recob::PFParticle, recob::PCAxis>)
+        , artPFPartClusAssociations(new art::Assns<recob::PFParticle, recob::Cluster>)
+        , artPFPartSPAssociations(new art::Assns<recob::SpacePoint, recob::PFParticle>)
+        , artPFPartPPAssociations(new art::Assns<recob::SpacePoint, recob::PFParticle>)
+        , artPFPartSeedAssociations(new art::Assns<recob::PFParticle, recob::Seed>)
+        , artPFPartEdgeAssociations(new art::Assns<recob::Edge, recob::PFParticle>)
+        , artPFPartPathEdgeAssociations(new art::Assns<recob::Edge, recob::PFParticle>)
+        , artSeedHitAssociations(new art::Assns<recob::Seed, recob::Hit>)
+        , artSPHitAssociations(new art::Assns<recob::Hit, recob::SpacePoint>)
+        , artPPHitAssociations(new art::Assns<recob::Hit, recob::SpacePoint>)
+        , artEdgeSPAssociations(new art::Assns<recob::SpacePoint, recob::Edge>)
+        , artEdgePPAssociations(new art::Assns<recob::SpacePoint, recob::Edge>)
         , fEvt(evt)
         , fSPPtrMaker(evt)
         , fSPPtrMakerPath(evt, pathName)
@@ -236,36 +232,32 @@ namespace lar_cluster3d {
           util::CreateAssn(fEvt, edgeVector, spacePoint, edgeSPAssociations, path);
       }
 
-      void outputObjects(bool spacePointsOnly)
+      void outputObjects()
       {
+        fEvt.put(std::move(artPCAxisVector));
+        fEvt.put(std::move(artPFParticleVector));
+        fEvt.put(std::move(artClusterVector));
         fEvt.put(std::move(artSpacePointVector));
+        fEvt.put(std::move(artSeedVector));
+        fEvt.put(std::move(artEdgeVector));
+        fEvt.put(std::move(artPFPartAxisAssociations));
+        fEvt.put(std::move(artPFPartClusAssociations));
+        fEvt.put(std::move(artClusterAssociations));
+        fEvt.put(std::move(artPFPartSPAssociations));
+        fEvt.put(std::move(artPFPartSeedAssociations));
+        fEvt.put(std::move(artPFPartEdgeAssociations));
+        fEvt.put(std::move(artSeedHitAssociations));
         fEvt.put(std::move(artSPHitAssociations));
-
-        //        if (!spacePointsOnly)
-        {
-          fEvt.put(std::move(artPCAxisVector));
-          fEvt.put(std::move(artPFParticleVector));
-          fEvt.put(std::move(artClusterVector));
-          fEvt.put(std::move(artSeedVector));
-          fEvt.put(std::move(artEdgeVector));
-          fEvt.put(std::move(artPFPartAxisAssociations));
-          fEvt.put(std::move(artPFPartClusAssociations));
-          fEvt.put(std::move(artClusterAssociations));
-          fEvt.put(std::move(artPFPartSPAssociations));
-          fEvt.put(std::move(artPFPartSeedAssociations));
-          fEvt.put(std::move(artPFPartEdgeAssociations));
-          fEvt.put(std::move(artSeedHitAssociations));
-          fEvt.put(std::move(artEdgeSPAssociations));
-          fEvt.put(std::move(artPathEdgeVector), fPathName);
-          fEvt.put(std::move(artPathPointVector), fPathName);
-          fEvt.put(std::move(artEdgePPAssociations), fPathName);
-          fEvt.put(std::move(artPFPartPPAssociations), fPathName);
-          fEvt.put(std::move(artPFPartPathEdgeAssociations), fPathName);
-          fEvt.put(std::move(artPPHitAssociations), fPathName);
-          fEvt.put(std::move(artVertexEdgeVector), fVertexName);
-          fEvt.put(std::move(artVertexPointVector), fVertexName);
-          fEvt.put(std::move(artExtremePointVector), fExtremeName);
-        }
+        fEvt.put(std::move(artEdgeSPAssociations));
+        fEvt.put(std::move(artPathEdgeVector), fPathName);
+        fEvt.put(std::move(artPathPointVector), fPathName);
+        fEvt.put(std::move(artEdgePPAssociations), fPathName);
+        fEvt.put(std::move(artPFPartPPAssociations), fPathName);
+        fEvt.put(std::move(artPFPartPathEdgeAssociations), fPathName);
+        fEvt.put(std::move(artPPHitAssociations), fPathName);
+        fEvt.put(std::move(artVertexEdgeVector), fVertexName);
+        fEvt.put(std::move(artVertexPointVector), fVertexName);
+        fEvt.put(std::move(artExtremePointVector), fExtremeName);
       }
 
       art::Ptr<recob::SpacePoint> makeSpacePointPtr(size_t index, const std::string& instance = "")
@@ -280,12 +272,10 @@ namespace lar_cluster3d {
         return fEdgePtrMakerPath(index);
       };
 
-      std::unique_ptr<std::vector<recob::SpacePoint>> artSpacePointVector;
-      std::unique_ptr<art::Assns<recob::Hit, recob::SpacePoint>> artSPHitAssociations;
-
       std::unique_ptr<std::vector<recob::PCAxis>> artPCAxisVector;
       std::unique_ptr<std::vector<recob::PFParticle>> artPFParticleVector;
       std::unique_ptr<std::vector<recob::Cluster>> artClusterVector;
+      std::unique_ptr<std::vector<recob::SpacePoint>> artSpacePointVector;
       std::unique_ptr<std::vector<recob::SpacePoint>> artPathPointVector;
       std::unique_ptr<std::vector<recob::SpacePoint>> artVertexPointVector;
       std::unique_ptr<std::vector<recob::SpacePoint>> artExtremePointVector;
@@ -303,6 +293,7 @@ namespace lar_cluster3d {
       std::unique_ptr<art::Assns<recob::Edge, recob::PFParticle>> artPFPartEdgeAssociations;
       std::unique_ptr<art::Assns<recob::Edge, recob::PFParticle>> artPFPartPathEdgeAssociations;
       std::unique_ptr<art::Assns<recob::Seed, recob::Hit>> artSeedHitAssociations;
+      std::unique_ptr<art::Assns<recob::Hit, recob::SpacePoint>> artSPHitAssociations;
       std::unique_ptr<art::Assns<recob::Hit, recob::SpacePoint>> artPPHitAssociations;
       std::unique_ptr<art::Assns<recob::SpacePoint, recob::Edge>> artEdgeSPAssociations;
       std::unique_ptr<art::Assns<recob::SpacePoint, recob::Edge>> artEdgePPAssociations;
@@ -344,15 +335,6 @@ namespace lar_cluster3d {
                         IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
                         std::vector<recob::Seed>& seedVec,
                         art::Assns<recob::Seed, recob::Hit>& seedHitAssns) const;
-
-    /**
-     *  @brief Attempt to split clusters by using a minimum spanning tree
-     *
-     *  @param clusterParameters     The given cluster parameters object to try to split
-     *  @param clusterParametersList The list of clusters
-     */
-    void splitClustersWithMST(reco::ClusterParameters& clusterParameters,
-                              reco::ClusterParametersList& clusterParametersList) const;
 
     /**
      *  @brief Attempt to split clusters using the output of the Hough Filter
@@ -562,41 +544,35 @@ namespace lar_cluster3d {
     // Handle special case of Space Point building outputting a new hit collection
     m_hit3DBuilderAlg->produces(producesCollector());
 
-    // we always output space points
+    produces<std::vector<recob::PCAxis>>();
+    produces<std::vector<recob::PFParticle>>();
+    produces<std::vector<recob::Cluster>>();
+    produces<std::vector<recob::Seed>>();
+    produces<std::vector<recob::Edge>>();
+
+    produces<art::Assns<recob::PFParticle, recob::PCAxis>>();
+    produces<art::Assns<recob::PFParticle, recob::Cluster>>();
+    produces<art::Assns<recob::PFParticle, recob::Seed>>();
+    produces<art::Assns<recob::Edge, recob::PFParticle>>();
+    produces<art::Assns<recob::Seed, recob::Hit>>();
+    produces<art::Assns<recob::Cluster, recob::Hit>>();
+
     produces<std::vector<recob::SpacePoint>>();
+    produces<art::Assns<recob::SpacePoint, recob::PFParticle>>();
     produces<art::Assns<recob::Hit, recob::SpacePoint>>();
+    produces<art::Assns<recob::SpacePoint, recob::Edge>>();
 
-    // Do we output anything else?
-    //    if (!m_onlyMakSpacePoints)
-    {
-      produces<std::vector<recob::PCAxis>>();
-      produces<std::vector<recob::PFParticle>>();
-      produces<std::vector<recob::Cluster>>();
-      produces<std::vector<recob::Seed>>();
-      produces<std::vector<recob::Edge>>();
+    produces<std::vector<recob::SpacePoint>>(m_pathInstance);
+    produces<std::vector<recob::Edge>>(m_pathInstance);
+    produces<art::Assns<recob::SpacePoint, recob::PFParticle>>(m_pathInstance);
+    produces<art::Assns<recob::Edge, recob::PFParticle>>(m_pathInstance);
+    produces<art::Assns<recob::Hit, recob::SpacePoint>>(m_pathInstance);
+    produces<art::Assns<recob::SpacePoint, recob::Edge>>(m_pathInstance);
 
-      produces<art::Assns<recob::PFParticle, recob::PCAxis>>();
-      produces<art::Assns<recob::PFParticle, recob::Cluster>>();
-      produces<art::Assns<recob::PFParticle, recob::Seed>>();
-      produces<art::Assns<recob::Edge, recob::PFParticle>>();
-      produces<art::Assns<recob::Seed, recob::Hit>>();
-      produces<art::Assns<recob::Cluster, recob::Hit>>();
+    produces<std::vector<recob::Edge>>(m_vertexInstance);
+    produces<std::vector<recob::SpacePoint>>(m_vertexInstance);
 
-      produces<art::Assns<recob::SpacePoint, recob::PFParticle>>();
-      produces<art::Assns<recob::SpacePoint, recob::Edge>>();
-
-      produces<std::vector<recob::SpacePoint>>(m_pathInstance);
-      produces<std::vector<recob::Edge>>(m_pathInstance);
-      produces<art::Assns<recob::SpacePoint, recob::PFParticle>>(m_pathInstance);
-      produces<art::Assns<recob::Edge, recob::PFParticle>>(m_pathInstance);
-      produces<art::Assns<recob::Hit, recob::SpacePoint>>(m_pathInstance);
-      produces<art::Assns<recob::SpacePoint, recob::Edge>>(m_pathInstance);
-
-      produces<std::vector<recob::Edge>>(m_vertexInstance);
-      produces<std::vector<recob::SpacePoint>>(m_vertexInstance);
-
-      produces<std::vector<recob::SpacePoint>>(m_extremeInstance);
-    }
+    produces<std::vector<recob::SpacePoint>>(m_extremeInstance);
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------
@@ -648,7 +624,8 @@ namespace lar_cluster3d {
       // Run the path finding
       m_clusterPathAlg->ModifyClusters(clusterParametersList);
     }
-    // Otherwise we only have two data objects to output
+
+    if (m_enableMonitoring) theClockFinish.start();
 
     // Get the art ouput object
     ArtOutputHandler output(evt, m_pathInstance, m_vertexInstance, m_extremeInstance);
@@ -659,16 +636,13 @@ namespace lar_cluster3d {
     auto const detProp =
       art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
     util::GeometryUtilities const gser{*lar::providerFrom<geo::Geometry>(),
-                                       art::ServiceHandle<geo::WireReadout>()->Get(),
+                                       art::ServiceHandle<geo::WireReadout const>()->Get(),
                                        clockData,
                                        detProp};
-
     ProduceArtClusters(gser, output, *hitPairList, clusterParametersList, clusterHitToArtPtrMap);
 
     // Output to art
-    output.outputObjects(m_onlyMakSpacePoints);
-
-    if (m_enableMonitoring) theClockFinish.start();
+    output.outputObjects();
 
     // If monitoring then deal with the fallout
     if (m_enableMonitoring) {
@@ -680,19 +654,14 @@ namespace lar_cluster3d {
       m_totalTime = theClockTotal.accumulated_real_time();
       m_artHitsTime = m_hit3DBuilderAlg->getTimeToExecute(IHit3DBuilder::COLLECTARTHITS);
       m_makeHitsTime = m_hit3DBuilderAlg->getTimeToExecute(IHit3DBuilder::BUILDTHREEDHITS);
-
-      if (!m_onlyMakSpacePoints) {
-        m_buildNeighborhoodTime = m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDHITTOHITMAP);
-        m_dbscanTime = m_clusterAlg->getTimeToExecute(IClusterAlg::RUNDBSCAN) +
-                       m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDCLUSTERINFO);
-        m_clusterMergeTime = m_clusterMergeAlg->getTimeToExecute();
-        m_pathFindingTime = m_clusterPathAlg->getTimeToExecute();
-      }
-
+      m_buildNeighborhoodTime = m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDHITTOHITMAP);
+      m_dbscanTime = m_clusterAlg->getTimeToExecute(IClusterAlg::RUNDBSCAN) +
+                     m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDCLUSTERINFO);
+      m_clusterMergeTime = m_clusterMergeAlg->getTimeToExecute();
+      m_pathFindingTime = m_clusterPathAlg->getTimeToExecute();
       m_finishTime = theClockFinish.accumulated_real_time();
       m_hits = static_cast<int>(clusterHitToArtPtrMap.size());
       m_hits3D = static_cast<int>(hitPairList->size());
-
       m_pRecoTree->Fill();
 
       mf::LogDebug("Cluster3D") << "*** Cluster3D total time: " << m_totalTime
@@ -841,178 +810,6 @@ namespace lar_cluster3d {
       return left.first < right.first;
     }
   };
-
-  void Cluster3D::splitClustersWithMST(reco::ClusterParameters& clusterParameters,
-                                       reco::ClusterParametersList& clusterParametersList) const
-  {
-    // This is being left in place for future development. Essentially, it was an attempt to implement
-    // a Minimum Spanning Tree as a way to split a particular cluster topology, one where two straight
-    // tracks cross closely enought to appear as one cluster. As of Feb 2, 2015 I think the idea is still
-    // worth merit so am leaving this module in place for now.
-    //
-    // If this routine is called then we believe we have a cluster which needs splitting.
-    // The way we will do this is to use a Minimum Spanning Tree algorithm to associate all
-    // hits together by their distance apart. In theory, we should be able to split the cluster
-    // by finding the largest distance and splitting at that point.
-    //
-    // Typedef some data structures that we will use.
-    // Start with the adjacency map
-    typedef std::pair<float, const reco::ClusterHit3D*> DistanceHit3DPair;
-    typedef std::list<DistanceHit3DPair> DistanceHit3DPairList;
-    typedef std::map<const reco::ClusterHit3D*, DistanceHit3DPairList> Hit3DToDistanceMap;
-
-    // Now typedef the lists we'll keep
-    typedef std::list<const reco::ClusterHit3D*> Hit3DList;
-    typedef std::pair<Hit3DList::iterator, Hit3DList::iterator> Hit3DEdgePair;
-    typedef std::pair<float, Hit3DEdgePair> DistanceEdgePair;
-    typedef std::list<DistanceEdgePair> DistanceEdgePairList;
-
-    struct DistanceEdgePairOrder {
-      bool operator()(const DistanceEdgePair& left, const DistanceEdgePair& right) const
-      {
-        return left.first > right.first;
-      }
-    };
-
-    // Recover the hits we'll work on.
-    // Note that we use on the skeleton hits so will need to recover them
-    reco::HitPairListPtr& hitPairListPtr = clusterParameters.getHitPairListPtr();
-    reco::HitPairListPtr skeletonListPtr;
-
-    // We want to work with the "skeleton" hits so first step is to call the algorithm to
-    // recover only these hits from the entire input collection
-    m_skeletonAlg.GetSkeletonHits(hitPairListPtr, skeletonListPtr);
-
-    // Skeleton hits are nice but we can do better if we then make a pass through to "average"
-    // the skeleton hits position in the Y-Z plane
-    m_skeletonAlg.AverageSkeletonPositions(skeletonListPtr);
-
-    // First task is to define and build the adjacency map
-    Hit3DToDistanceMap hit3DToDistanceMap;
-
-    for (reco::HitPairListPtr::const_iterator hit3DOuterItr = skeletonListPtr.begin();
-         hit3DOuterItr != skeletonListPtr.end();) {
-      const reco::ClusterHit3D* hit3DOuter = *hit3DOuterItr++;
-      DistanceHit3DPairList& outerHitList = hit3DToDistanceMap[hit3DOuter];
-      TVector3 outerPos(
-        hit3DOuter->getPosition()[0], hit3DOuter->getPosition()[1], hit3DOuter->getPosition()[2]);
-
-      for (reco::HitPairListPtr::const_iterator hit3DInnerItr = hit3DOuterItr;
-           hit3DInnerItr != skeletonListPtr.end();
-           hit3DInnerItr++) {
-        const reco::ClusterHit3D* hit3DInner = *hit3DInnerItr;
-        TVector3 innerPos(
-          hit3DInner->getPosition()[0], hit3DInner->getPosition()[1], hit3DInner->getPosition()[2]);
-        TVector3 deltaPos = innerPos - outerPos;
-        float hitDistance(float(deltaPos.Mag()));
-
-        if (hitDistance > 20.) continue;
-
-        hit3DToDistanceMap[hit3DInner].emplace_back(hitDistance, hit3DOuter);
-        outerHitList.emplace_back(hitDistance, hit3DInner);
-      }
-
-      // Make sure our membership bit is clear
-      hit3DOuter->clearStatusBits(reco::ClusterHit3D::SELECTEDBYMST);
-    }
-
-    // Make pass through again to order each of the lists
-    for (auto& mapPair : hit3DToDistanceMap) {
-      mapPair.second.sort(Hit3DDistanceOrder());
-    }
-
-    // Get the containers for the MST to operate on/with
-    Hit3DList hit3DList;
-    DistanceEdgePairList distanceEdgePairList;
-
-    // Initialize with first element
-    hit3DList.emplace_back(skeletonListPtr.front());
-    distanceEdgePairList.emplace_back(
-      DistanceEdgePair(0., Hit3DEdgePair(hit3DList.begin(), hit3DList.begin())));
-
-    skeletonListPtr.front()->setStatusBit(reco::ClusterHit3D::SELECTEDBYMST);
-
-    float largestDistance(0.);
-
-    // Now run the MST
-    // Basically, we loop until the MST list is the same size as the input list
-    while (hit3DList.size() < skeletonListPtr.size()) {
-      Hit3DList::iterator bestHit3DIter = hit3DList.begin();
-      float bestDist = 10000000.;
-
-      // Loop through all hits currently in the list and look for closest hit not in the list
-      for (Hit3DList::iterator hit3DIter = hit3DList.begin(); hit3DIter != hit3DList.end();
-           hit3DIter++) {
-        const reco::ClusterHit3D* hit3D = *hit3DIter;
-
-        // For the given 3D hit, find the closest to it that is not already in the list
-        DistanceHit3DPairList& nearestList = hit3DToDistanceMap[hit3D];
-
-        while (!nearestList.empty()) {
-          const reco::ClusterHit3D* hit3DToCheck = nearestList.front().second;
-
-          if (!hit3DToCheck->bitsAreSet(reco::ClusterHit3D::SELECTEDBYMST)) {
-            if (nearestList.front().first < bestDist) {
-              bestHit3DIter = hit3DIter;
-              bestDist = nearestList.front().first;
-            }
-            break;
-          }
-
-          nearestList.pop_front();
-        }
-      }
-
-      if (bestDist > largestDistance) largestDistance = bestDist;
-
-      // Now we add the best hit not in the list to our list, keep track of the distance
-      // to the object it was closest to
-      const reco::ClusterHit3D* bestHit3D = *bestHit3DIter; // "best" hit already in the list
-      const reco::ClusterHit3D* nextHit3D =
-        hit3DToDistanceMap[bestHit3D].front().second; // "next" hit we are adding to the list
-
-      Hit3DList::iterator nextHit3DIter = hit3DList.insert(hit3DList.end(), nextHit3D);
-
-      distanceEdgePairList.emplace_back(bestDist, Hit3DEdgePair(bestHit3DIter, nextHit3DIter));
-
-      nextHit3D->setStatusBit(reco::ClusterHit3D::SELECTEDBYMST);
-    }
-
-    float thirdDist = 2. * sqrt(clusterParameters.getSkeletonPCA().getEigenValues()[2]);
-
-    // Ok, find the largest distance in the iterator map
-    distanceEdgePairList.sort(DistanceEdgePairOrder());
-
-    DistanceEdgePairList::iterator largestDistIter = distanceEdgePairList.begin();
-
-    for (DistanceEdgePairList::iterator edgeIter = distanceEdgePairList.begin();
-         edgeIter != distanceEdgePairList.end();
-         edgeIter++) {
-      if (edgeIter->first < thirdDist) break;
-
-      largestDistIter = edgeIter;
-    }
-
-    reco::HitPairListPtr::iterator breakIter = largestDistIter->second.second;
-    reco::HitPairListPtr bestList;
-
-    bestList.resize(std::distance(hit3DList.begin(), breakIter));
-
-    std::copy(hit3DList.begin(), breakIter, bestList.begin());
-
-    // Remove from the grand hit list and see what happens...
-    // The pieces below are incomplete and were really for testing only.
-    hitPairListPtr.sort();
-    bestList.sort();
-
-    reco::HitPairListPtr::iterator newListEnd = std::set_difference(hitPairListPtr.begin(),
-                                                                    hitPairListPtr.end(),
-                                                                    bestList.begin(),
-                                                                    bestList.end(),
-                                                                    hitPairListPtr.begin());
-
-    hitPairListPtr.erase(newListEnd, hitPairListPtr.end());
-  }
 
   class CopyIfInRange {
   public:
@@ -1346,9 +1143,6 @@ namespace lar_cluster3d {
       }
     }
 
-    mf::LogDebug("Cluster3D") << "--> Preparing to save the remaining space points, there are "
-                              << hitPairVector.size() << std::endl;
-
     // Right now error matrix is uniform...
     int nFreePoints(0);
 
@@ -1364,7 +1158,10 @@ namespace lar_cluster3d {
       RecobHitVector recobHits;
 
       for (const auto hit : hitPair.getHits()) {
-        if (!hit) continue;
+        if (!hit) {
+          chisq = -1000.;
+          continue;
+        }
 
         art::Ptr<recob::Hit> hitPtr = hitToPtrMap[hit->getHit()];
         recobHits.push_back(hitPtr);
@@ -1383,8 +1180,8 @@ namespace lar_cluster3d {
           *output.artSpacePointVector.get(), recobHits, *output.artSPHitAssociations.get());
     }
 
-    mf::LogDebug("Cluster3D") << "++++>>>> total num hits: " << hitPairVector.size()
-                              << ", num free: " << nFreePoints;
+    std::cout << "++++>>>> total num hits: " << hitPairVector.size()
+              << ", num free: " << nFreePoints << std::endl;
   }
 
   size_t Cluster3D::countUltimateDaughters(reco::ClusterParameters& clusterParameters) const
@@ -1671,7 +1468,7 @@ namespace lar_cluster3d {
     spacePointVec.reserve(spacePointVec.size() + clusHitPairVector.size());
 
     // Right now error matrix is uniform...
-    double spError[] = {0., 0., 0., 0., 0., 0.};
+    double spError[] = {1., 0., 1., 0., 0., 1.};
 
     // Copy these hits to the vector to be stored with the event
     for (auto& hitPair : clusHitPairVector) {
@@ -1885,4 +1682,4 @@ namespace lar_cluster3d {
     }
   }
 
-} // namespace lar_Cluster3D
+} // namespace lar_cluster3d

--- a/larreco/ClusterFinder/Cluster3D_module.cc
+++ b/larreco/ClusterFinder/Cluster3D_module.cc
@@ -574,7 +574,7 @@ namespace lar_cluster3d {
     produces<art::Assns<recob::Hit, recob::SpacePoint>>();
 
     // Do we output anything else?
-//    if (!m_onlyMakSpacePoints)
+    if (!m_onlyMakSpacePoints)
     {
       produces<std::vector<recob::PCAxis>>();
       produces<std::vector<recob::PFParticle>>();

--- a/larreco/ClusterFinder/Cluster3D_module.cc
+++ b/larreco/ClusterFinder/Cluster3D_module.cc
@@ -45,9 +45,8 @@
 
 // Framework Includes
 #include "art/Framework/Core/EDProducer.h"
-#include "art/Framework/Core/ModuleMacros.h"
 #include "art/Framework/Principal/Event.h"
-#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Framework/Core/ModuleMacros.h"
 #include "art/Persistency/Common/PtrMaker.h"
 #include "art/Utilities/make_tool.h"
 #include "art_root_io/TFileService.h"
@@ -121,30 +120,30 @@ namespace lar_cluster3d {
                        std::string& pathName,
                        std::string& vertexName,
                        std::string& extremeName)
-        : artPCAxisVector(new std::vector<recob::PCAxis>)
-        , artPFParticleVector(new std::vector<recob::PFParticle>)
-        , artClusterVector(new std::vector<recob::Cluster>)
-        , artSpacePointVector(new std::vector<recob::SpacePoint>)
-        , artPathPointVector(new std::vector<recob::SpacePoint>)
-        , artVertexPointVector(new std::vector<recob::SpacePoint>)
-        , artExtremePointVector(new std::vector<recob::SpacePoint>)
-        , artSeedVector(new std::vector<recob::Seed>)
-        , artEdgeVector(new std::vector<recob::Edge>)
-        , artPathEdgeVector(new std::vector<recob::Edge>)
-        , artVertexEdgeVector(new std::vector<recob::Edge>)
-        , artClusterAssociations(new art::Assns<recob::Cluster, recob::Hit>)
-        , artPFPartAxisAssociations(new art::Assns<recob::PFParticle, recob::PCAxis>)
-        , artPFPartClusAssociations(new art::Assns<recob::PFParticle, recob::Cluster>)
-        , artPFPartSPAssociations(new art::Assns<recob::SpacePoint, recob::PFParticle>)
-        , artPFPartPPAssociations(new art::Assns<recob::SpacePoint, recob::PFParticle>)
-        , artPFPartSeedAssociations(new art::Assns<recob::PFParticle, recob::Seed>)
-        , artPFPartEdgeAssociations(new art::Assns<recob::Edge, recob::PFParticle>)
-        , artPFPartPathEdgeAssociations(new art::Assns<recob::Edge, recob::PFParticle>)
-        , artSeedHitAssociations(new art::Assns<recob::Seed, recob::Hit>)
-        , artSPHitAssociations(new art::Assns<recob::Hit, recob::SpacePoint>)
-        , artPPHitAssociations(new art::Assns<recob::Hit, recob::SpacePoint>)
-        , artEdgeSPAssociations(new art::Assns<recob::SpacePoint, recob::Edge>)
-        , artEdgePPAssociations(new art::Assns<recob::SpacePoint, recob::Edge>)
+        : artSpacePointVector(std::make_unique<std::vector<recob::SpacePoint>>())
+        , artSPHitAssociations(std::make_unique<art::Assns<recob::Hit, recob::SpacePoint>>())
+        , artPCAxisVector(std::make_unique<std::vector<recob::PCAxis>>())
+        , artPFParticleVector(std::make_unique<std::vector<recob::PFParticle>>())
+        , artClusterVector(std::make_unique<std::vector<recob::Cluster>>())
+        , artPathPointVector(std::make_unique<std::vector<recob::SpacePoint>>())
+        , artVertexPointVector(std::make_unique<std::vector<recob::SpacePoint>>())
+        , artExtremePointVector(std::make_unique<std::vector<recob::SpacePoint>>())
+        , artSeedVector(std::make_unique<std::vector<recob::Seed>>())
+        , artEdgeVector(std::make_unique<std::vector<recob::Edge>>())
+        , artPathEdgeVector(std::make_unique<std::vector<recob::Edge>>())
+        , artVertexEdgeVector(std::make_unique<std::vector<recob::Edge>>())
+        , artClusterAssociations(std::make_unique<art::Assns<recob::Cluster, recob::Hit>>())
+        , artPFPartAxisAssociations(std::make_unique<art::Assns<recob::PFParticle, recob::PCAxis>>())
+        , artPFPartClusAssociations(std::make_unique<art::Assns<recob::PFParticle, recob::Cluster>>())
+        , artPFPartSPAssociations(std::make_unique<art::Assns<recob::SpacePoint, recob::PFParticle>>())
+        , artPFPartPPAssociations(std::make_unique<art::Assns<recob::SpacePoint, recob::PFParticle>>())
+        , artPFPartSeedAssociations(std::make_unique<art::Assns<recob::PFParticle, recob::Seed>>())
+        , artPFPartEdgeAssociations(std::make_unique<art::Assns<recob::Edge, recob::PFParticle>>())
+        , artPFPartPathEdgeAssociations(std::make_unique<art::Assns<recob::Edge, recob::PFParticle>>())
+        , artSeedHitAssociations(std::make_unique<art::Assns<recob::Seed, recob::Hit>>())
+        , artPPHitAssociations(std::make_unique<art::Assns<recob::Hit, recob::SpacePoint>>())
+        , artEdgeSPAssociations(std::make_unique<art::Assns<recob::SpacePoint, recob::Edge>>())
+        , artEdgePPAssociations(std::make_unique<art::Assns<recob::SpacePoint, recob::Edge>>())
         , fEvt(evt)
         , fSPPtrMaker(evt)
         , fSPPtrMakerPath(evt, pathName)
@@ -155,21 +154,24 @@ namespace lar_cluster3d {
         , fExtremeName(extremeName)
       {}
 
-      void makeClusterHitAssns(RecobHitVector& recobHits)
+      void
+      makeClusterHitAssns(RecobHitVector& recobHits)
       {
         util::CreateAssn(fEvt, *artClusterVector, recobHits, *artClusterAssociations);
       }
 
-      void makeSpacePointHitAssns(std::vector<recob::SpacePoint>& spacePointVector,
-                                  RecobHitVector& recobHits,
-                                  art::Assns<recob::Hit, recob::SpacePoint>& spHitAssns,
-                                  const std::string& path = "")
+      void
+      makeSpacePointHitAssns(std::vector<recob::SpacePoint>& spacePointVector,
+                             RecobHitVector& recobHits,
+                             art::Assns<recob::Hit, recob::SpacePoint>& spHitAssns,
+                             const std::string& path = "")
       {
         for (auto& hit : recobHits)
           util::CreateAssn(fEvt, spacePointVector, hit, spHitAssns, path);
       }
 
-      void makePFPartPCAAssns()
+      void
+      makePFPartPCAAssns()
       {
         util::CreateAssn(fEvt,
                          *artPFParticleVector,
@@ -179,7 +181,8 @@ namespace lar_cluster3d {
                          artPCAxisVector->size());
       }
 
-      void makePFPartSeedAssns(size_t numSeedsStart)
+      void
+      makePFPartSeedAssns(size_t numSeedsStart)
       {
         util::CreateAssn(fEvt,
                          *artPFParticleVector,
@@ -189,7 +192,8 @@ namespace lar_cluster3d {
                          artSeedVector->size());
       }
 
-      void makePFPartClusterAssns(size_t clusterStart)
+      void
+      makePFPartClusterAssns(size_t clusterStart)
       {
         util::CreateAssn(fEvt,
                          *artPFParticleVector,
@@ -199,7 +203,8 @@ namespace lar_cluster3d {
                          artClusterVector->size());
       }
 
-      void makePFPartSpacePointAssns(
+      void
+      makePFPartSpacePointAssns(
         std::vector<recob::SpacePoint>& spacePointVector,
         art::Assns<recob::SpacePoint, recob::PFParticle>& pfPartSPAssociations,
         size_t spacePointStart,
@@ -211,10 +216,11 @@ namespace lar_cluster3d {
         }
       }
 
-      void makePFPartEdgeAssns(std::vector<recob::Edge>& edgeVector,
-                               art::Assns<recob::Edge, recob::PFParticle>& pfPartEdgeAssociations,
-                               size_t edgeStart,
-                               const std::string& instance = "")
+      void
+      makePFPartEdgeAssns(std::vector<recob::Edge>& edgeVector,
+                          art::Assns<recob::Edge, recob::PFParticle>& pfPartEdgeAssociations,
+                          size_t edgeStart,
+                          const std::string& instance = "")
       {
         for (size_t idx = edgeStart; idx < edgeVector.size(); idx++) {
           art::Ptr<recob::Edge> edge = makeEdgePtr(idx, instance);
@@ -223,59 +229,69 @@ namespace lar_cluster3d {
         }
       }
 
-      void makeEdgeSpacePointAssns(std::vector<recob::Edge>& edgeVector,
-                                   RecobSpacePointVector& spacePointVector,
-                                   art::Assns<recob::SpacePoint, recob::Edge>& edgeSPAssociations,
-                                   const std::string& path = "")
+      void
+      makeEdgeSpacePointAssns(std::vector<recob::Edge>& edgeVector,
+                              RecobSpacePointVector& spacePointVector,
+                              art::Assns<recob::SpacePoint, recob::Edge>& edgeSPAssociations,
+                              const std::string& path = "")
       {
         for (auto& spacePoint : spacePointVector)
           util::CreateAssn(fEvt, edgeVector, spacePoint, edgeSPAssociations, path);
       }
 
-      void outputObjects()
+      void
+      outputObjects(bool spacePointsOnly)
       {
-        fEvt.put(std::move(artPCAxisVector));
-        fEvt.put(std::move(artPFParticleVector));
-        fEvt.put(std::move(artClusterVector));
         fEvt.put(std::move(artSpacePointVector));
-        fEvt.put(std::move(artSeedVector));
-        fEvt.put(std::move(artEdgeVector));
-        fEvt.put(std::move(artPFPartAxisAssociations));
-        fEvt.put(std::move(artPFPartClusAssociations));
-        fEvt.put(std::move(artClusterAssociations));
-        fEvt.put(std::move(artPFPartSPAssociations));
-        fEvt.put(std::move(artPFPartSeedAssociations));
-        fEvt.put(std::move(artPFPartEdgeAssociations));
-        fEvt.put(std::move(artSeedHitAssociations));
         fEvt.put(std::move(artSPHitAssociations));
-        fEvt.put(std::move(artEdgeSPAssociations));
-        fEvt.put(std::move(artPathEdgeVector), fPathName);
-        fEvt.put(std::move(artPathPointVector), fPathName);
-        fEvt.put(std::move(artEdgePPAssociations), fPathName);
-        fEvt.put(std::move(artPFPartPPAssociations), fPathName);
-        fEvt.put(std::move(artPFPartPathEdgeAssociations), fPathName);
-        fEvt.put(std::move(artPPHitAssociations), fPathName);
-        fEvt.put(std::move(artVertexEdgeVector), fVertexName);
-        fEvt.put(std::move(artVertexPointVector), fVertexName);
-        fEvt.put(std::move(artExtremePointVector), fExtremeName);
+
+//        if (!spacePointsOnly)
+        {
+          fEvt.put(std::move(artPCAxisVector));
+          fEvt.put(std::move(artPFParticleVector));
+          fEvt.put(std::move(artClusterVector));
+          fEvt.put(std::move(artSeedVector));
+          fEvt.put(std::move(artEdgeVector));
+          fEvt.put(std::move(artPFPartAxisAssociations));
+          fEvt.put(std::move(artPFPartClusAssociations));
+          fEvt.put(std::move(artClusterAssociations));
+          fEvt.put(std::move(artPFPartSPAssociations));
+          fEvt.put(std::move(artPFPartSeedAssociations));
+          fEvt.put(std::move(artPFPartEdgeAssociations));
+          fEvt.put(std::move(artSeedHitAssociations));
+          fEvt.put(std::move(artEdgeSPAssociations));
+          fEvt.put(std::move(artPathEdgeVector), fPathName);
+          fEvt.put(std::move(artPathPointVector), fPathName);
+          fEvt.put(std::move(artEdgePPAssociations), fPathName);
+          fEvt.put(std::move(artPFPartPPAssociations), fPathName);
+          fEvt.put(std::move(artPFPartPathEdgeAssociations), fPathName);
+          fEvt.put(std::move(artPPHitAssociations), fPathName);
+          fEvt.put(std::move(artVertexEdgeVector), fVertexName);
+          fEvt.put(std::move(artVertexPointVector), fVertexName);
+          fEvt.put(std::move(artExtremePointVector), fExtremeName);
+        }
       }
 
-      art::Ptr<recob::SpacePoint> makeSpacePointPtr(size_t index, const std::string& instance = "")
+      art::Ptr<recob::SpacePoint>
+      makeSpacePointPtr(size_t index, const std::string& instance = "")
       {
         if (empty(instance)) { return fSPPtrMaker(index); }
         return fSPPtrMakerPath(index);
       };
 
-      art::Ptr<recob::Edge> makeEdgePtr(size_t index, const std::string& instance = "")
+      art::Ptr<recob::Edge>
+      makeEdgePtr(size_t index, const std::string& instance = "")
       {
         if (empty(instance)) { return fEdgePtrMaker(index); }
         return fEdgePtrMakerPath(index);
       };
 
+      std::unique_ptr<std::vector<recob::SpacePoint>> artSpacePointVector;
+      std::unique_ptr<art::Assns<recob::Hit, recob::SpacePoint>> artSPHitAssociations;
+
       std::unique_ptr<std::vector<recob::PCAxis>> artPCAxisVector;
       std::unique_ptr<std::vector<recob::PFParticle>> artPFParticleVector;
       std::unique_ptr<std::vector<recob::Cluster>> artClusterVector;
-      std::unique_ptr<std::vector<recob::SpacePoint>> artSpacePointVector;
       std::unique_ptr<std::vector<recob::SpacePoint>> artPathPointVector;
       std::unique_ptr<std::vector<recob::SpacePoint>> artVertexPointVector;
       std::unique_ptr<std::vector<recob::SpacePoint>> artExtremePointVector;
@@ -293,7 +309,6 @@ namespace lar_cluster3d {
       std::unique_ptr<art::Assns<recob::Edge, recob::PFParticle>> artPFPartEdgeAssociations;
       std::unique_ptr<art::Assns<recob::Edge, recob::PFParticle>> artPFPartPathEdgeAssociations;
       std::unique_ptr<art::Assns<recob::Seed, recob::Hit>> artSeedHitAssociations;
-      std::unique_ptr<art::Assns<recob::Hit, recob::SpacePoint>> artSPHitAssociations;
       std::unique_ptr<art::Assns<recob::Hit, recob::SpacePoint>> artPPHitAssociations;
       std::unique_ptr<art::Assns<recob::SpacePoint, recob::Edge>> artEdgeSPAssociations;
       std::unique_ptr<art::Assns<recob::SpacePoint, recob::Edge>> artEdgePPAssociations;
@@ -335,6 +350,15 @@ namespace lar_cluster3d {
                         IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
                         std::vector<recob::Seed>& seedVec,
                         art::Assns<recob::Seed, recob::Hit>& seedHitAssns) const;
+
+    /**
+     *  @brief Attempt to split clusters by using a minimum spanning tree
+     *
+     *  @param clusterParameters     The given cluster parameters object to try to split
+     *  @param clusterParametersList The list of clusters
+     */
+    void splitClustersWithMST(reco::ClusterParameters& clusterParameters,
+                              reco::ClusterParametersList& clusterParametersList) const;
 
     /**
      *  @brief Attempt to split clusters using the output of the Hough Filter
@@ -446,7 +470,8 @@ namespace lar_cluster3d {
      *
      *  @param pca  The Principal Components Analysis parameters for the cluster
      */
-    bool aParallelHitsCluster(const reco::PrincipalComponents& pca) const
+    bool
+    aParallelHitsCluster(const reco::PrincipalComponents& pca) const
     {
       return fabs(pca.getEigenVectors().row(2)(0)) > m_parallelHitsCosAng &&
              3. * sqrt(pca.getEigenValues()(1)) > m_parallelHitsTransWid;
@@ -544,40 +569,47 @@ namespace lar_cluster3d {
     // Handle special case of Space Point building outputting a new hit collection
     m_hit3DBuilderAlg->produces(producesCollector());
 
-    produces<std::vector<recob::PCAxis>>();
-    produces<std::vector<recob::PFParticle>>();
-    produces<std::vector<recob::Cluster>>();
-    produces<std::vector<recob::Seed>>();
-    produces<std::vector<recob::Edge>>();
-
-    produces<art::Assns<recob::PFParticle, recob::PCAxis>>();
-    produces<art::Assns<recob::PFParticle, recob::Cluster>>();
-    produces<art::Assns<recob::PFParticle, recob::Seed>>();
-    produces<art::Assns<recob::Edge, recob::PFParticle>>();
-    produces<art::Assns<recob::Seed, recob::Hit>>();
-    produces<art::Assns<recob::Cluster, recob::Hit>>();
-
+    // we always output space points
     produces<std::vector<recob::SpacePoint>>();
-    produces<art::Assns<recob::SpacePoint, recob::PFParticle>>();
     produces<art::Assns<recob::Hit, recob::SpacePoint>>();
-    produces<art::Assns<recob::SpacePoint, recob::Edge>>();
 
-    produces<std::vector<recob::SpacePoint>>(m_pathInstance);
-    produces<std::vector<recob::Edge>>(m_pathInstance);
-    produces<art::Assns<recob::SpacePoint, recob::PFParticle>>(m_pathInstance);
-    produces<art::Assns<recob::Edge, recob::PFParticle>>(m_pathInstance);
-    produces<art::Assns<recob::Hit, recob::SpacePoint>>(m_pathInstance);
-    produces<art::Assns<recob::SpacePoint, recob::Edge>>(m_pathInstance);
+    // Do we output anything else?
+//    if (!m_onlyMakSpacePoints)
+    {
+      produces<std::vector<recob::PCAxis>>();
+      produces<std::vector<recob::PFParticle>>();
+      produces<std::vector<recob::Cluster>>();
+      produces<std::vector<recob::Seed>>();
+      produces<std::vector<recob::Edge>>();
 
-    produces<std::vector<recob::Edge>>(m_vertexInstance);
-    produces<std::vector<recob::SpacePoint>>(m_vertexInstance);
+      produces<art::Assns<recob::PFParticle, recob::PCAxis>>();
+      produces<art::Assns<recob::PFParticle, recob::Cluster>>();
+      produces<art::Assns<recob::PFParticle, recob::Seed>>();
+      produces<art::Assns<recob::Edge, recob::PFParticle>>();
+      produces<art::Assns<recob::Seed, recob::Hit>>();
+      produces<art::Assns<recob::Cluster, recob::Hit>>();
 
-    produces<std::vector<recob::SpacePoint>>(m_extremeInstance);
+      produces<art::Assns<recob::SpacePoint, recob::PFParticle>>();
+      produces<art::Assns<recob::SpacePoint, recob::Edge>>();
+
+      produces<std::vector<recob::SpacePoint>>(m_pathInstance);
+      produces<std::vector<recob::Edge>>(m_pathInstance);
+      produces<art::Assns<recob::SpacePoint, recob::PFParticle>>(m_pathInstance);
+      produces<art::Assns<recob::Edge, recob::PFParticle>>(m_pathInstance);
+      produces<art::Assns<recob::Hit, recob::SpacePoint>>(m_pathInstance);
+      produces<art::Assns<recob::SpacePoint, recob::Edge>>(m_pathInstance);
+
+      produces<std::vector<recob::Edge>>(m_vertexInstance);
+      produces<std::vector<recob::SpacePoint>>(m_vertexInstance);
+
+      produces<std::vector<recob::SpacePoint>>(m_extremeInstance);
+    }
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void Cluster3D::beginJob()
+  void
+  Cluster3D::beginJob()
   {
     /**
      *  @brief beginJob will be tasked with initializing monitoring, in necessary, but also to init the
@@ -588,11 +620,12 @@ namespace lar_cluster3d {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void Cluster3D::produce(art::Event& evt)
+  void
+  Cluster3D::produce(art::Event& evt)
   {
     mf::LogInfo("Cluster3D") << " *** Cluster3D::produce(...)  [Run=" << evt.run()
-                             << ", Event=" << evt.id().event() << "] Starting Now! *** "
-                             << std::endl;
+                                << ", Event=" << evt.id().event() << "] Starting Now! *** "
+                                << std::endl;
 
     // Set up for monitoring the timing... at some point this should be removed in favor of
     // external profilers
@@ -607,14 +640,14 @@ namespace lar_cluster3d {
     // Get instances of the primary data structures needed
     reco::ClusterParametersList clusterParametersList;
     IHit3DBuilder::RecobHitToPtrMap clusterHitToArtPtrMap;
-    std::unique_ptr<reco::HitPairList> hitPairList(
-      new reco::HitPairList); // Potentially lots of hits, use heap instead of stack
+    std::unique_ptr<reco::HitPairList> hitPairList(new reco::HitPairList); // Potentially lots of hits, use heap instead of stack
 
     // Call the algorithm that builds 3D hits and stores the hit collection
     m_hit3DBuilderAlg->Hit3DBuilder(evt, *hitPairList, clusterHitToArtPtrMap);
 
     // Only do the rest if we are not in the mode of only building space points (requested by ML folks)
-    if (!m_onlyMakSpacePoints) {
+    if (!m_onlyMakSpacePoints) 
+    {
       // Call the main workhorse algorithm for building the local version of candidate 3D clusters
       m_clusterAlg->Cluster3DHits(*hitPairList, clusterParametersList);
 
@@ -633,16 +666,16 @@ namespace lar_cluster3d {
     // Call the module that does the end processing (of which there is quite a bit of work!)
     // This goes here to insure that something is always written to the data store
     auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
-    auto const detProp =
-      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
+    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
     util::GeometryUtilities const gser{*lar::providerFrom<geo::Geometry>(),
-                                       art::ServiceHandle<geo::WireReadout const>()->Get(),
+                                       art::ServiceHandle<geo::WireReadout>()->Get(),
                                        clockData,
                                        detProp};
+
     ProduceArtClusters(gser, output, *hitPairList, clusterParametersList, clusterHitToArtPtrMap);
 
     // Output to art
-    output.outputObjects();
+    output.outputObjects(m_onlyMakSpacePoints);
 
     // If monitoring then deal with the fallout
     if (m_enableMonitoring) {
@@ -654,23 +687,29 @@ namespace lar_cluster3d {
       m_totalTime = theClockTotal.accumulated_real_time();
       m_artHitsTime = m_hit3DBuilderAlg->getTimeToExecute(IHit3DBuilder::COLLECTARTHITS);
       m_makeHitsTime = m_hit3DBuilderAlg->getTimeToExecute(IHit3DBuilder::BUILDTHREEDHITS);
-      m_buildNeighborhoodTime = m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDHITTOHITMAP);
-      m_dbscanTime = m_clusterAlg->getTimeToExecute(IClusterAlg::RUNDBSCAN) +
-                     m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDCLUSTERINFO);
-      m_clusterMergeTime = m_clusterMergeAlg->getTimeToExecute();
-      m_pathFindingTime = m_clusterPathAlg->getTimeToExecute();
+
+      if (!m_onlyMakSpacePoints)
+      {
+        m_buildNeighborhoodTime = m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDHITTOHITMAP);
+        m_dbscanTime = m_clusterAlg->getTimeToExecute(IClusterAlg::RUNDBSCAN) +
+                       m_clusterAlg->getTimeToExecute(IClusterAlg::BUILDCLUSTERINFO);
+        m_clusterMergeTime = m_clusterMergeAlg->getTimeToExecute();
+        m_pathFindingTime = m_clusterPathAlg->getTimeToExecute();
+      }
+
       m_finishTime = theClockFinish.accumulated_real_time();
       m_hits = static_cast<int>(clusterHitToArtPtrMap.size());
       m_hits3D = static_cast<int>(hitPairList->size());
+
       m_pRecoTree->Fill();
 
       mf::LogDebug("Cluster3D") << "*** Cluster3D total time: " << m_totalTime
-                                << ", art: " << m_artHitsTime << ", make: " << m_makeHitsTime
-                                << ", build: " << m_buildNeighborhoodTime
-                                << ", clustering: " << m_dbscanTime
-                                << ", merge: " << m_clusterMergeTime
-                                << ", path: " << m_pathFindingTime << ", finish: " << m_finishTime
-                                << std::endl;
+                                   << ", art: " << m_artHitsTime << ", make: " << m_makeHitsTime
+                                   << ", build: " << m_buildNeighborhoodTime
+                                   << ", clustering: " << m_dbscanTime
+                                   << ", merge: " << m_clusterMergeTime
+                                   << ", path: " << m_pathFindingTime << ", finish: " << m_finishTime
+                                   << std::endl;
     }
 
     // Will we ever get here? ;-)
@@ -679,7 +718,8 @@ namespace lar_cluster3d {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void Cluster3D::InitializeMonitoring()
+  void
+  Cluster3D::InitializeMonitoring()
   {
     art::ServiceHandle<art::TFileService> tfs;
     m_pRecoTree = tfs->make<TTree>("monitoring", "LAr Reco");
@@ -701,7 +741,8 @@ namespace lar_cluster3d {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void Cluster3D::PrepareEvent(const art::Event& evt)
+  void
+  Cluster3D::PrepareEvent(const art::Event& evt)
   {
     m_run = evt.run();
     m_event = evt.id().event();
@@ -718,11 +759,12 @@ namespace lar_cluster3d {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  void Cluster3D::findTrackSeeds(art::Event& evt,
-                                 reco::ClusterParameters& cluster,
-                                 IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
-                                 std::vector<recob::Seed>& seedVec,
-                                 art::Assns<recob::Seed, recob::Hit>& seedHitAssns) const
+  void
+  Cluster3D::findTrackSeeds(art::Event& evt,
+                                  reco::ClusterParameters& cluster,
+                                  IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
+                                  std::vector<recob::Seed>& seedVec,
+                                  art::Assns<recob::Seed, recob::Hit>& seedHitAssns) const
   {
     /**
      *  @brief This method provides an interface to various algorithms for finding candiate
@@ -804,18 +846,194 @@ namespace lar_cluster3d {
   }
 
   struct Hit3DDistanceOrder {
-    bool operator()(const std::pair<float, const reco::ClusterHit3D*>& left,
-                    const std::pair<float, const reco::ClusterHit3D*>& right)
+    bool
+    operator()(const std::pair<float, const reco::ClusterHit3D*>& left,
+               const std::pair<float, const reco::ClusterHit3D*>& right)
     {
       return left.first < right.first;
     }
   };
 
+  void
+  Cluster3D::splitClustersWithMST(reco::ClusterParameters& clusterParameters,
+                                        reco::ClusterParametersList& clusterParametersList) const
+  {
+    // This is being left in place for future development. Essentially, it was an attempt to implement
+    // a Minimum Spanning Tree as a way to split a particular cluster topology, one where two straight
+    // tracks cross closely enought to appear as one cluster. As of Feb 2, 2015 I think the idea is still
+    // worth merit so am leaving this module in place for now.
+    //
+    // If this routine is called then we believe we have a cluster which needs splitting.
+    // The way we will do this is to use a Minimum Spanning Tree algorithm to associate all
+    // hits together by their distance apart. In theory, we should be able to split the cluster
+    // by finding the largest distance and splitting at that point.
+    //
+    // Typedef some data structures that we will use.
+    // Start with the adjacency map
+    typedef std::pair<float, const reco::ClusterHit3D*> DistanceHit3DPair;
+    typedef std::list<DistanceHit3DPair> DistanceHit3DPairList;
+    typedef std::map<const reco::ClusterHit3D*, DistanceHit3DPairList> Hit3DToDistanceMap;
+
+    // Now typedef the lists we'll keep
+    typedef std::list<const reco::ClusterHit3D*> Hit3DList;
+    typedef std::pair<Hit3DList::iterator, Hit3DList::iterator> Hit3DEdgePair;
+    typedef std::pair<float, Hit3DEdgePair> DistanceEdgePair;
+    typedef std::list<DistanceEdgePair> DistanceEdgePairList;
+
+    struct DistanceEdgePairOrder {
+      bool
+      operator()(const DistanceEdgePair& left, const DistanceEdgePair& right) const
+      {
+        return left.first > right.first;
+      }
+    };
+
+    // Recover the hits we'll work on.
+    // Note that we use on the skeleton hits so will need to recover them
+    reco::HitPairListPtr& hitPairListPtr = clusterParameters.getHitPairListPtr();
+    reco::HitPairListPtr skeletonListPtr;
+
+    // We want to work with the "skeleton" hits so first step is to call the algorithm to
+    // recover only these hits from the entire input collection
+    m_skeletonAlg.GetSkeletonHits(hitPairListPtr, skeletonListPtr);
+
+    // Skeleton hits are nice but we can do better if we then make a pass through to "average"
+    // the skeleton hits position in the Y-Z plane
+    m_skeletonAlg.AverageSkeletonPositions(skeletonListPtr);
+
+    // First task is to define and build the adjacency map
+    Hit3DToDistanceMap hit3DToDistanceMap;
+
+    for (reco::HitPairListPtr::const_iterator hit3DOuterItr = skeletonListPtr.begin();
+         hit3DOuterItr != skeletonListPtr.end();) {
+      const reco::ClusterHit3D* hit3DOuter = *hit3DOuterItr++;
+      DistanceHit3DPairList& outerHitList = hit3DToDistanceMap[hit3DOuter];
+      TVector3 outerPos(
+        hit3DOuter->getPosition()[0], hit3DOuter->getPosition()[1], hit3DOuter->getPosition()[2]);
+
+      for (reco::HitPairListPtr::const_iterator hit3DInnerItr = hit3DOuterItr;
+           hit3DInnerItr != skeletonListPtr.end();
+           hit3DInnerItr++) {
+        const reco::ClusterHit3D* hit3DInner = *hit3DInnerItr;
+        TVector3 innerPos(
+          hit3DInner->getPosition()[0], hit3DInner->getPosition()[1], hit3DInner->getPosition()[2]);
+        TVector3 deltaPos = innerPos - outerPos;
+        float hitDistance(float(deltaPos.Mag()));
+
+        if (hitDistance > 20.) continue;
+
+        hit3DToDistanceMap[hit3DInner].emplace_back(hitDistance, hit3DOuter);
+        outerHitList.emplace_back(hitDistance, hit3DInner);
+      }
+
+      // Make sure our membership bit is clear
+      hit3DOuter->clearStatusBits(reco::ClusterHit3D::SELECTEDBYMST);
+    }
+
+    // Make pass through again to order each of the lists
+    for (auto& mapPair : hit3DToDistanceMap) {
+      mapPair.second.sort(Hit3DDistanceOrder());
+    }
+
+    // Get the containers for the MST to operate on/with
+    Hit3DList hit3DList;
+    DistanceEdgePairList distanceEdgePairList;
+
+    // Initialize with first element
+    hit3DList.emplace_back(skeletonListPtr.front());
+    distanceEdgePairList.emplace_back(
+      DistanceEdgePair(0., Hit3DEdgePair(hit3DList.begin(), hit3DList.begin())));
+
+    skeletonListPtr.front()->setStatusBit(reco::ClusterHit3D::SELECTEDBYMST);
+
+    float largestDistance(0.);
+
+    // Now run the MST
+    // Basically, we loop until the MST list is the same size as the input list
+    while (hit3DList.size() < skeletonListPtr.size()) {
+      Hit3DList::iterator bestHit3DIter = hit3DList.begin();
+      float bestDist = 10000000.;
+
+      // Loop through all hits currently in the list and look for closest hit not in the list
+      for (Hit3DList::iterator hit3DIter = hit3DList.begin(); hit3DIter != hit3DList.end();
+           hit3DIter++) {
+        const reco::ClusterHit3D* hit3D = *hit3DIter;
+
+        // For the given 3D hit, find the closest to it that is not already in the list
+        DistanceHit3DPairList& nearestList = hit3DToDistanceMap[hit3D];
+
+        while (!nearestList.empty()) {
+          const reco::ClusterHit3D* hit3DToCheck = nearestList.front().second;
+
+          if (!hit3DToCheck->bitsAreSet(reco::ClusterHit3D::SELECTEDBYMST)) {
+            if (nearestList.front().first < bestDist) {
+              bestHit3DIter = hit3DIter;
+              bestDist = nearestList.front().first;
+            }
+            break;
+          }
+
+          nearestList.pop_front();
+        }
+      }
+
+      if (bestDist > largestDistance) largestDistance = bestDist;
+
+      // Now we add the best hit not in the list to our list, keep track of the distance
+      // to the object it was closest to
+      const reco::ClusterHit3D* bestHit3D = *bestHit3DIter; // "best" hit already in the list
+      const reco::ClusterHit3D* nextHit3D =
+        hit3DToDistanceMap[bestHit3D].front().second; // "next" hit we are adding to the list
+
+      Hit3DList::iterator nextHit3DIter = hit3DList.insert(hit3DList.end(), nextHit3D);
+
+      distanceEdgePairList.emplace_back(bestDist, Hit3DEdgePair(bestHit3DIter, nextHit3DIter));
+
+      nextHit3D->setStatusBit(reco::ClusterHit3D::SELECTEDBYMST);
+    }
+
+    float thirdDist = 2. * sqrt(clusterParameters.getSkeletonPCA().getEigenValues()[2]);
+
+    // Ok, find the largest distance in the iterator map
+    distanceEdgePairList.sort(DistanceEdgePairOrder());
+
+    DistanceEdgePairList::iterator largestDistIter = distanceEdgePairList.begin();
+
+    for (DistanceEdgePairList::iterator edgeIter = distanceEdgePairList.begin();
+         edgeIter != distanceEdgePairList.end();
+         edgeIter++) {
+      if (edgeIter->first < thirdDist) break;
+
+      largestDistIter = edgeIter;
+    }
+
+    reco::HitPairListPtr::iterator breakIter = largestDistIter->second.second;
+    reco::HitPairListPtr bestList;
+
+    bestList.resize(std::distance(hit3DList.begin(), breakIter));
+
+    std::copy(hit3DList.begin(), breakIter, bestList.begin());
+
+    // Remove from the grand hit list and see what happens...
+    // The pieces below are incomplete and were really for testing only.
+    hitPairListPtr.sort();
+    bestList.sort();
+
+    reco::HitPairListPtr::iterator newListEnd = std::set_difference(hitPairListPtr.begin(),
+                                                                    hitPairListPtr.end(),
+                                                                    bestList.begin(),
+                                                                    bestList.end(),
+                                                                    hitPairListPtr.begin());
+
+    hitPairListPtr.erase(newListEnd, hitPairListPtr.end());
+  }
+
   class CopyIfInRange {
   public:
     CopyIfInRange(float maxRange) : m_maxRange(maxRange) {}
 
-    bool operator()(const reco::ClusterHit3D* hit3D) const
+    bool
+    operator()(const reco::ClusterHit3D* hit3D) const
     {
       return hit3D->getDocaToAxis() < m_maxRange;
     }
@@ -824,8 +1042,9 @@ namespace lar_cluster3d {
     float m_maxRange;
   };
 
-  void Cluster3D::splitClustersWithHough(reco::ClusterParameters& clusterParameters,
-                                         reco::ClusterParametersList& clusterParametersList) const
+  void
+  Cluster3D::splitClustersWithHough(reco::ClusterParameters& clusterParameters,
+                                          reco::ClusterParametersList& clusterParametersList) const
   {
     // @brief A method for splitted "crossed tracks" clusters into separate clusters
     //
@@ -967,11 +1186,12 @@ namespace lar_cluster3d {
     }
   }
 
-  void Cluster3D::ProduceArtClusters(util::GeometryUtilities const& gser,
-                                     ArtOutputHandler& output,
-                                     reco::HitPairList& hitPairVector,
-                                     reco::ClusterParametersList& clusterParametersList,
-                                     IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap) const
+  void
+  Cluster3D::ProduceArtClusters(util::GeometryUtilities const& gser,
+                                      ArtOutputHandler& output,
+                                      reco::HitPairList& hitPairVector,
+                                      reco::ClusterParametersList& clusterParametersList,
+                                      IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap) const
   {
     /**
      *  @brief The workhorse to take the candidate 3D clusters and produce all of the necessary art output
@@ -1143,48 +1363,49 @@ namespace lar_cluster3d {
       }
     }
 
+    mf::LogDebug("Cluster3D") << "--> Preparing to save the remaining space points, there are " << hitPairVector.size() << std::endl;
+
     // Right now error matrix is uniform...
     int nFreePoints(0);
 
     // Run through the HitPairVector and add any unused hit pairs to the list
-    for (auto& hitPair : hitPairVector) {
-      if (hitPair.bitsAreSet(reco::ClusterHit3D::MADESPACEPOINT)) continue;
+    for (auto& hitPair : hitPairVector) 
+    {
+        if (hitPair.bitsAreSet(reco::ClusterHit3D::MADESPACEPOINT)) continue;
 
-      double spacePointPos[] = {
-        hitPair.getPosition()[0], hitPair.getPosition()[1], hitPair.getPosition()[2]};
-      double spacePointErr[] = {1., 0., 0., 1., 0., 1.};
-      double chisq = hitPair.getHitChiSquare();
+        double spacePointPos[] = {
+          hitPair.getPosition()[0], hitPair.getPosition()[1], hitPair.getPosition()[2]};
+        double spacePointErr[] = {1., 0., 0., 1., 0., 1.};
+        double chisq = hitPair.getHitChiSquare();
 
-      RecobHitVector recobHits;
+        RecobHitVector recobHits;
 
-      for (const auto hit : hitPair.getHits()) {
-        if (!hit) {
-          chisq = -1000.;
-          continue;
+        for (const auto hit : hitPair.getHits()) {
+          if (!hit) continue;
+
+          art::Ptr<recob::Hit> hitPtr = hitToPtrMap[hit->getHit()];
+          recobHits.push_back(hitPtr);
         }
 
-        art::Ptr<recob::Hit> hitPtr = hitToPtrMap[hit->getHit()];
-        recobHits.push_back(hitPtr);
-      }
+        nFreePoints++;
 
-      nFreePoints++;
+        spacePointErr[1] = hitPair.getTotalCharge();
+        spacePointErr[3] = hitPair.getChargeAsymmetry();
 
-      spacePointErr[1] = hitPair.getTotalCharge();
-      spacePointErr[3] = hitPair.getChargeAsymmetry();
+        output.artSpacePointVector->push_back(
+          recob::SpacePoint(spacePointPos, spacePointErr, chisq, output.artSpacePointVector->size()));
 
-      output.artSpacePointVector->push_back(
-        recob::SpacePoint(spacePointPos, spacePointErr, chisq, output.artSpacePointVector->size()));
+        if (!recobHits.empty())
+          output.makeSpacePointHitAssns(
+            *output.artSpacePointVector.get(), recobHits, *output.artSPHitAssociations.get());
+    } 
 
-      if (!recobHits.empty())
-        output.makeSpacePointHitAssns(
-          *output.artSpacePointVector.get(), recobHits, *output.artSPHitAssociations.get());
-    }
-
-    std::cout << "++++>>>> total num hits: " << hitPairVector.size()
-              << ", num free: " << nFreePoints << std::endl;
+    mf::LogDebug("Cluster3D") << "++++>>>> total num hits: " << hitPairVector.size()
+              << ", num free: " << nFreePoints;
   }
 
-  size_t Cluster3D::countUltimateDaughters(reco::ClusterParameters& clusterParameters) const
+  size_t
+  Cluster3D::countUltimateDaughters(reco::ClusterParameters& clusterParameters) const
   {
     size_t localCount(0);
 
@@ -1198,14 +1419,15 @@ namespace lar_cluster3d {
     return localCount;
   }
 
-  size_t Cluster3D::FindAndStoreDaughters(util::GeometryUtilities const& gser,
-                                          ArtOutputHandler& output,
-                                          reco::ClusterParameters& clusterParameters,
-                                          size_t pfParticleParent,
-                                          IdxToPCAMap& idxToPCAMap,
-                                          IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
-                                          Hit3DToSPPtrMap& hit3DToSPPtrMap,
-                                          Hit3DToSPPtrMap& best3DToSPPtrMap) const
+  size_t
+  Cluster3D::FindAndStoreDaughters(util::GeometryUtilities const& gser,
+                                         ArtOutputHandler& output,
+                                         reco::ClusterParameters& clusterParameters,
+                                         size_t pfParticleParent,
+                                         IdxToPCAMap& idxToPCAMap,
+                                         IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
+                                         Hit3DToSPPtrMap& hit3DToSPPtrMap,
+                                         Hit3DToSPPtrMap& best3DToSPPtrMap) const
   {
     // This is a recursive routine, we keep calling ourself as long as the daughter list is non empty
     if (!clusterParameters.daughterList().empty()) {
@@ -1235,13 +1457,14 @@ namespace lar_cluster3d {
     return idxToPCAMap.size();
   }
 
-  size_t Cluster3D::ConvertToArtOutput(util::GeometryUtilities const& gser,
-                                       ArtOutputHandler& output,
-                                       reco::ClusterParameters& clusterParameters,
-                                       size_t pfParticleParent,
-                                       IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
-                                       Hit3DToSPPtrMap& hit3DToSPPtrMap,
-                                       Hit3DToSPPtrMap& best3DToSPPtrMap) const
+  size_t
+  Cluster3D::ConvertToArtOutput(util::GeometryUtilities const& gser,
+                                      ArtOutputHandler& output,
+                                      reco::ClusterParameters& clusterParameters,
+                                      size_t pfParticleParent,
+                                      IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
+                                      Hit3DToSPPtrMap& hit3DToSPPtrMap,
+                                      Hit3DToSPPtrMap& best3DToSPPtrMap) const
   {
     // prepare the algorithm to compute the cluster characteristics;
     // we use the "standard" one here, except that we override selected items
@@ -1456,19 +1679,20 @@ namespace lar_cluster3d {
     return pfParticleIdx;
   }
 
-  void Cluster3D::MakeAndSaveSpacePoints(ArtOutputHandler& output,
-                                         std::vector<recob::SpacePoint>& spacePointVec,
-                                         art::Assns<recob::Hit, recob::SpacePoint>& spHitAssns,
-                                         reco::HitPairListPtr& clusHitPairVector,
-                                         IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
-                                         Hit3DToSPPtrMap& hit3DToSPPtrMap,
-                                         const std::string& instance) const
+  void
+  Cluster3D::MakeAndSaveSpacePoints(ArtOutputHandler& output,
+                                          std::vector<recob::SpacePoint>& spacePointVec,
+                                          art::Assns<recob::Hit, recob::SpacePoint>& spHitAssns,
+                                          reco::HitPairListPtr& clusHitPairVector,
+                                          IHit3DBuilder::RecobHitToPtrMap& hitToPtrMap,
+                                          Hit3DToSPPtrMap& hit3DToSPPtrMap,
+                                          const std::string& instance) const
   {
     // Reserve space...
     spacePointVec.reserve(spacePointVec.size() + clusHitPairVector.size());
 
     // Right now error matrix is uniform...
-    double spError[] = {1., 0., 1., 0., 0., 1.};
+    double spError[] = {0., 0., 0., 0., 0., 0.};
 
     // Copy these hits to the vector to be stored with the event
     for (auto& hitPair : clusHitPairVector) {
@@ -1513,8 +1737,9 @@ namespace lar_cluster3d {
     return;
   }
 
-  void Cluster3D::MakeAndSaveKinkPoints(ArtOutputHandler& output,
-                                        reco::ConvexHullKinkTupleList& kinkTupleVec) const
+  void
+  Cluster3D::MakeAndSaveKinkPoints(ArtOutputHandler& output,
+                                         reco::ConvexHullKinkTupleList& kinkTupleVec) const
   {
     // Right now error matrix is uniform...
     double spError[] = {1., 0., 1., 0., 0., 1.};
@@ -1539,9 +1764,10 @@ namespace lar_cluster3d {
     return;
   }
 
-  void Cluster3D::MakeAndSaveVertexPoints(ArtOutputHandler& output,
-                                          dcel2d::VertexList& vertexList,
-                                          dcel2d::HalfEdgeList& halfEdgeList) const
+  void
+  Cluster3D::MakeAndSaveVertexPoints(ArtOutputHandler& output,
+                                           dcel2d::VertexList& vertexList,
+                                           dcel2d::HalfEdgeList& halfEdgeList) const
   {
     // We actually do two things here:
     // 1) Create space points to represent the vertex locations of the voronoi diagram
@@ -1604,9 +1830,10 @@ namespace lar_cluster3d {
     return;
   }
 
-  void Cluster3D::MakeAndSavePCAPoints(ArtOutputHandler& output,
-                                       const reco::PrincipalComponents& fullPCA,
-                                       IdxToPCAMap& idxToPCAMap) const
+  void
+  Cluster3D::MakeAndSavePCAPoints(ArtOutputHandler& output,
+                                        const reco::PrincipalComponents& fullPCA,
+                                        IdxToPCAMap& idxToPCAMap) const
   {
     // We actually do two things here:
     // 1) Create space points from the centroids of the PCA for each cluster
@@ -1682,4 +1909,4 @@ namespace lar_cluster3d {
     }
   }
 
-} // namespace lar_cluster3d
+} // namespace lar_Cluster3D

--- a/larreco/RecoAlg/Cluster3DAlgs/SnippetHit3DBuilder_tool.cc
+++ b/larreco/RecoAlg/Cluster3DAlgs/SnippetHit3DBuilder_tool.cc
@@ -23,24 +23,24 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 // LArSoft includes
-#include "larcore/Geometry/WireReadout.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/Geometry/WireReadout.h"
 #include "lardata/ArtDataHelper/HitCreator.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardataobj/RecoBase/Hit.h"
-#include "larevt/CalibrationDBI/Interface/ChannelStatusService.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
+#include "larevt/CalibrationDBI/Interface/ChannelStatusService.h"
 #include "larreco/RecoAlg/Cluster3DAlgs/IHit3DBuilder.h"
 
 // Eigen
 #include <Eigen/Core>
 
 // std includes
-#include <string>
 #include <iostream>
 #include <memory>
 #include <numeric> // std::accumulate
+#include <string>
 
 // Ack!
 #include "TH1F.h"
@@ -51,43 +51,41 @@
 
 namespace lar_cluster3d {
 
-/**
+  /**
  *   @brief What follows are several highly useful typedefs which we
  *          want to expose to the outside world
  */
 
-// forward declaration to define an ordering function for our hit set
-struct Hit2DSetCompare
-{
-    bool operator() (const reco::ClusterHit2D*, const reco::ClusterHit2D*) const;
-};
+  // forward declaration to define an ordering function for our hit set
+  struct Hit2DSetCompare {
+    bool operator()(const reco::ClusterHit2D*, const reco::ClusterHit2D*) const;
+  };
 
-using HitVector                    = std::vector<const reco::ClusterHit2D*>;
-using HitStartEndPair              = std::pair<raw::TDCtick_t,raw::TDCtick_t>;
-using SnippetHitMap                = std::map<HitStartEndPair,HitVector>;
-using PlaneToSnippetHitMap         = std::map<geo::PlaneID, SnippetHitMap>;
-using TPCToPlaneToSnippetHitMap    = std::map<geo::TPCID, PlaneToSnippetHitMap>;
-using Hit2DList                    = std::list<reco::ClusterHit2D>;
-using Hit2DSet                     = std::set<const reco::ClusterHit2D*, Hit2DSetCompare>;
-using WireToHitSetMap              = std::map<unsigned int, Hit2DSet>;
-using PlaneToWireToHitSetMap       = std::map<geo::PlaneID, WireToHitSetMap>;
-using TPCToPlaneToWireToHitSetMap  = std::map<geo::TPCID, PlaneToWireToHitSetMap>;
-using HitVectorMap                 = std::map<size_t, HitVector>;
-using SnippetHitMapItrPair         = std::pair<SnippetHitMap::iterator,SnippetHitMap::iterator>;
-using PlaneSnippetHitMapItrPairVec = std::vector<SnippetHitMapItrPair>;
+  using HitVector = std::vector<const reco::ClusterHit2D*>;
+  using HitStartEndPair = std::pair<raw::TDCtick_t, raw::TDCtick_t>;
+  using SnippetHitMap = std::map<HitStartEndPair, HitVector>;
+  using PlaneToSnippetHitMap = std::map<geo::PlaneID, SnippetHitMap>;
+  using TPCToPlaneToSnippetHitMap = std::map<geo::TPCID, PlaneToSnippetHitMap>;
+  using Hit2DList = std::list<reco::ClusterHit2D>;
+  using Hit2DSet = std::set<const reco::ClusterHit2D*, Hit2DSetCompare>;
+  using WireToHitSetMap = std::map<unsigned int, Hit2DSet>;
+  using PlaneToWireToHitSetMap = std::map<geo::PlaneID, WireToHitSetMap>;
+  using TPCToPlaneToWireToHitSetMap = std::map<geo::TPCID, PlaneToWireToHitSetMap>;
+  using HitVectorMap = std::map<size_t, HitVector>;
+  using SnippetHitMapItrPair = std::pair<SnippetHitMap::iterator, SnippetHitMap::iterator>;
+  using PlaneSnippetHitMapItrPairVec = std::vector<SnippetHitMapItrPair>;
 
-/**
+  /**
  *  @brief  SnippetHit3DBuilder class definiton
  */
-class SnippetHit3DBuilder : virtual public IHit3DBuilder
-{
-public:
+  class SnippetHit3DBuilder : virtual public IHit3DBuilder {
+  public:
     /**
      *  @brief  Constructor
      *
      *  @param  pset
      */
-    explicit SnippetHit3DBuilder(fhicl::ParameterSet const &pset);
+    explicit SnippetHit3DBuilder(fhicl::ParameterSet const& pset);
 
     /**
      *  @brief Each algorithm may have different objects it wants "produced" so use this to
@@ -108,10 +106,12 @@ public:
     /**
      *  @brief If monitoring, recover the time to execute a particular function
      */
-    virtual float getTimeToExecute(IHit3DBuilder::TimeValues index) const override {return m_timeVector[index];}
+    virtual float getTimeToExecute(IHit3DBuilder::TimeValues index) const override
+    {
+      return m_timeVector[index];
+    }
 
-private:
-
+  private:
     /**
      *  @brief  Extract the ART hits and the ART hit-particle relationships
      *
@@ -127,48 +127,66 @@ private:
     /**
      *  @brief Create a new 2D hit collection from hits associated to 3D space points
      */
-    void CreateNewRecobHitCollection(art::Event&, reco::HitPairList&, std::vector<recob::Hit>&, RecobHitToPtrMap&);
+    void CreateNewRecobHitCollection(art::Event&,
+                                     reco::HitPairList&,
+                                     std::vector<recob::Hit>&,
+                                     RecobHitToPtrMap&);
 
     /**
      *  @brief Create recob::Wire to recob::Hit associations
      */
-    void makeWireAssns(const art::Event&, art::Assns<recob::Wire, recob::Hit>&, RecobHitToPtrMap&) const;
+    void makeWireAssns(const art::Event&,
+                       art::Assns<recob::Wire, recob::Hit>&,
+                       RecobHitToPtrMap&) const;
 
     /**
      *  @brief Create raw::RawDigit to recob::Hit associations
      */
-    void makeRawDigitAssns(const art::Event&, art::Assns<raw::RawDigit, recob::Hit>&, RecobHitToPtrMap&) const;
+    void makeRawDigitAssns(const art::Event&,
+                           art::Assns<raw::RawDigit, recob::Hit>&,
+                           RecobHitToPtrMap&) const;
 
     /**
      *  @brief Given the ClusterHit2D objects, build the HitPairMap
      */
-    size_t BuildHitPairMap(PlaneToSnippetHitMap& planeToHitVectorMap, reco::HitPairList& hitPairList) const;
+    size_t BuildHitPairMap(PlaneToSnippetHitMap& planeToHitVectorMap,
+                           reco::HitPairList& hitPairList) const;
 
     /**
      * @brief This defines a structure allowing us to see which hits have already been matched. Generally, if two
      *        hits have been matched then there is no point considering them anymore as it simply means duplicate
      *        space points will be created
      */
-    using MatchedHitMap = std::unordered_map<const reco::ClusterHit2D*,std::set<const reco::ClusterHit2D*>>;
+    using MatchedHitMap =
+      std::unordered_map<const reco::ClusterHit2D*, std::set<const reco::ClusterHit2D*>>;
 
     /**
      *  @brief Given the ClusterHit2D objects, build the HitPairMap
      */
-    size_t BuildHitPairMapByTPC(PlaneSnippetHitMapItrPairVec& planeSnippetHitMapItrPairVec, reco::HitPairList& hitPairList) const;
+    size_t BuildHitPairMapByTPC(PlaneSnippetHitMapItrPairVec& planeSnippetHitMapItrPairVec,
+                                reco::HitPairList& hitPairList) const;
 
     /**
      *  @brief This builds a list of candidate hit pairs from lists of hits on two planes
      */
-    using HitMatchTriplet       = std::tuple<const reco::ClusterHit2D*,const reco::ClusterHit2D*,const reco::ClusterHit3D>;
-    using HitMatchTripletVec    = std::vector<HitMatchTriplet>;
-    using HitMatchTripletVecMap = std::map<geo::WireID,HitMatchTripletVec>;
+    using HitMatchTriplet =
+      std::tuple<const reco::ClusterHit2D*, const reco::ClusterHit2D*, const reco::ClusterHit3D>;
+    using HitMatchTripletVec = std::vector<HitMatchTriplet>;
+    using HitMatchTripletVecMap = std::map<geo::WireID, HitMatchTripletVec>;
 
-    int findGoodHitPairs(SnippetHitMap::iterator&, SnippetHitMap::iterator&, SnippetHitMap::iterator&, HitMatchTripletVecMap&) const;
+    int findGoodHitPairs(SnippetHitMap::iterator&,
+                         SnippetHitMap::iterator&,
+                         SnippetHitMap::iterator&,
+                         HitMatchTripletVecMap&) const;
 
     /**
      *  @brief This algorithm takes lists of hit pairs and finds good triplets
      */
-    void findGoodTriplets(HitMatchTripletVecMap&, HitMatchTripletVecMap&, MatchedHitMap&, reco::HitPairList&, bool = false) const;
+    void findGoodTriplets(HitMatchTripletVecMap&,
+                          HitMatchTripletVecMap&,
+                          MatchedHitMap&,
+                          reco::HitPairList&,
+                          bool = false) const;
 
     /**
      * @brief This will look at storing pair "orphans" where the 2D hits are otherwise unused
@@ -185,17 +203,17 @@ private:
     /**
      *  @brief Make a HitPair object by checking two hits
      */
-    bool makeHitPair(reco::ClusterHit3D&       pairOut,
+    bool makeHitPair(reco::ClusterHit3D& pairOut,
                      const reco::ClusterHit2D* hit1,
                      const reco::ClusterHit2D* hit2,
-                     float                     hitWidthSclFctr = 1.,
-                     size_t                    hitPairCntr = 0) const;
+                     float hitWidthSclFctr = 1.,
+                     size_t hitPairCntr = 0) const;
 
     /**
      *  @brief Make a 3D HitPair object by checking two hits
      */
-    bool makeHitTriplet(reco::ClusterHit3D&       pairOut,
-                        MatchedHitMap&            matchedHitMap,
+    bool makeHitTriplet(reco::ClusterHit3D& pairOut,
+                        MatchedHitMap& matchedHitMap,
                         const reco::ClusterHit3D& pairIn,
                         const reco::ClusterHit2D* hit2) const;
 
@@ -208,17 +226,26 @@ private:
     /**
      * @brief function to compute the distance of closest approach and the arc length to the points of closest approach
      */
-    float closestApproach(const Eigen::Vector3f&, const Eigen::Vector3f&, const Eigen::Vector3f&, const Eigen::Vector3f&, float&, float&) const;
+    float closestApproach(const Eigen::Vector3f&,
+                          const Eigen::Vector3f&,
+                          const Eigen::Vector3f&,
+                          const Eigen::Vector3f&,
+                          float&,
+                          float&) const;
 
     /**
      *  @brief A utility routine for finding a 2D hit closest in time to the given pair
      */
-    const reco::ClusterHit2D* FindBestMatchingHit(const Hit2DSet& hit2DSet, const reco::ClusterHit3D& pair, float pairDeltaTimeLimits) const;
+    const reco::ClusterHit2D* FindBestMatchingHit(const Hit2DSet& hit2DSet,
+                                                  const reco::ClusterHit3D& pair,
+                                                  float pairDeltaTimeLimits) const;
 
     /**
      *  @brief A utility routine for returning the number of 2D hits from the list in a given range
      */
-    int FindNumberInRange(const Hit2DSet& hit2DSet, const reco::ClusterHit3D& pair, float range) const;
+    int FindNumberInRange(const Hit2DSet& hit2DSet,
+                          const reco::ClusterHit3D& pair,
+                          float range) const;
 
     /**
      *  @brief Jacket the calls to finding the nearest wire in order to intercept the exceptions if out of range
@@ -228,12 +255,13 @@ private:
     /**
      *  @brief Jacket the calls to finding the nearest wire in order to intercept the exceptions if out of range
      */
-    float DistanceFromPointToHitWire(const Eigen::Vector3f& position, const geo::WireID& wireID) const;
+    float DistanceFromPointToHitWire(const Eigen::Vector3f& position,
+                                     const geo::WireID& wireID) const;
 
     /**
      * @brief Perform charge integration between limits
      */
-    float chargeIntegral(float,float,float,float,int,int) const;
+    float chargeIntegral(float, float, float, float, int, int) const;
 
     /**
      *  @brief clear the tuple vectors before processing next event
@@ -245,122 +273,125 @@ private:
      */
     using TickCorrectionArray = std::vector<std::vector<std::vector<float>>>;
 
-    std::vector<art::InputTag>              m_hitFinderTagVec;
-    float                                   m_hitWidthSclFctr;
-    float                                   m_deltaPeakTimeSig;
-    float                                   m_rangeNumSig;
-    float                                   m_LongHitStretchFctr;
-    float                                   m_pulseHeightFrac;
-    float                                   m_PHLowSelection;
-    float                                   m_minPHFor2HitPoints;    ///< Set a minimum pulse height for 2 hit space point candidates
-    std::vector<int>                        m_invalidTPCVec;
-    float                                   m_wirePitchScaleFactor;  ///< Scaling factor to determine max distance allowed between candidate pairs
-    float                                   m_maxHit3DChiSquare;     ///< Provide ability to select hits based on "chi square"
-    bool                                    m_saveBadChannelPairs;   ///< Should we save pairs consistent with bad channels?
-    bool                                    m_saveMythicalPoints;    ///< Should we save valid 2 hit space points? 
-    float                                   m_maxMythicalChiSquare;  ///< Selection cut on mythical points
-    bool                                    m_useT0Offsets;          ///< If true then we will use the LArSoft interplane offsets
-    bool                                    m_outputHistograms;      ///< Take the time to create and fill some histograms for diagnostics
-    bool                                    m_makeAssociations;      ///< Do we make wire/rawdigit associations to space points?
+    std::vector<art::InputTag> m_hitFinderTagVec;
+    float m_hitWidthSclFctr;
+    float m_deltaPeakTimeSig;
+    float m_rangeNumSig;
+    float m_LongHitStretchFctr;
+    float m_pulseHeightFrac;
+    float m_PHLowSelection;
+    float m_minPHFor2HitPoints; ///< Set a minimum pulse height for 2 hit space point candidates
+    std::vector<int> m_invalidTPCVec;
+    float
+      m_wirePitchScaleFactor; ///< Scaling factor to determine max distance allowed between candidate pairs
+    float m_maxHit3DChiSquare;    ///< Provide ability to select hits based on "chi square"
+    bool m_saveBadChannelPairs;   ///< Should we save pairs consistent with bad channels?
+    bool m_saveMythicalPoints;    ///< Should we save valid 2 hit space points?
+    float m_maxMythicalChiSquare; ///< Selection cut on mythical points
+    bool m_useT0Offsets;          ///< If true then we will use the LArSoft interplane offsets
+    bool m_outputHistograms; ///< Take the time to create and fill some histograms for diagnostics
+    bool m_makeAssociations; ///< Do we make wire/rawdigit associations to space points?
 
-    bool                                    m_enableMonitoring;      ///<
-    float                                   m_wirePitch[3];
-    mutable std::vector<float>              m_timeVector;            ///<
+    bool m_enableMonitoring; ///<
+    float m_wirePitch[3];
+    mutable std::vector<float> m_timeVector; ///<
 
-    float                                   m_zPosOffset;
+    float m_zPosOffset;
 
-    using PlaneToT0OffsetMap = std::map<geo::PlaneID,float>;
+    using PlaneToT0OffsetMap = std::map<geo::PlaneID, float>;
 
-    PlaneToT0OffsetMap                      m_PlaneToT0OffsetMap;
+    PlaneToT0OffsetMap m_PlaneToT0OffsetMap;
 
-    // Define some basic histograms   
-    TTree*                                  m_tupleTree;             ///< output analysis tree
+    // Define some basic histograms
+    TTree* m_tupleTree; ///< output analysis tree
 
-    mutable std::vector<float>              m_deltaPeakTimePlane0Vec;
-    mutable std::vector<float>              m_deltaPeakSigmaPlane0Vec;
-    mutable std::vector<float>              m_deltaPeakTimePlane1Vec;
-    mutable std::vector<float>              m_deltaPeakSigmaPlane1Vec;
-    mutable std::vector<float>              m_deltaPeakTimePlane2Vec;
-    mutable std::vector<float>              m_deltaPeakSigmaPlane2Vec;
+    mutable std::vector<float> m_deltaPeakTimePlane0Vec;
+    mutable std::vector<float> m_deltaPeakSigmaPlane0Vec;
+    mutable std::vector<float> m_deltaPeakTimePlane1Vec;
+    mutable std::vector<float> m_deltaPeakSigmaPlane1Vec;
+    mutable std::vector<float> m_deltaPeakTimePlane2Vec;
+    mutable std::vector<float> m_deltaPeakSigmaPlane2Vec;
 
-    mutable std::vector<float>              m_deltaTimeVec;
-    mutable std::vector<float>              m_deltaTime0Vec;
-    mutable std::vector<float>              m_deltaSigma0Vec;
-    mutable std::vector<float>              m_deltaTime1Vec;
-    mutable std::vector<float>              m_deltaSigma1Vec;
-    mutable std::vector<float>              m_deltaTime2Vec;
-    mutable std::vector<float>              m_deltaSigma2Vec;
-    mutable std::vector<float>              m_chiSquare3DVec;
-    mutable std::vector<float>              m_maxPullVec;
-    mutable std::vector<float>              m_overlapFractionVec;
-    mutable std::vector<float>              m_overlapRangeVec;
-    mutable std::vector<float>              m_maxDeltaPeakVec;
-    mutable std::vector<float>              m_maxSideVecVec;
-    mutable std::vector<float>              m_pairWireDistVec;
-    mutable std::vector<float>              m_smallChargeDiffVec;
-    mutable std::vector<int>                m_smallIndexVec;
-    mutable std::vector<float>              m_qualityMetricVec;
-    mutable std::vector<float>              m_spacePointChargeVec;
-    mutable std::vector<float>              m_hitAsymmetryVec;
-    mutable std::vector<float>              m_2hit1stPHVec;
-    mutable std::vector<float>              m_2hit2ndPHVec;
-    mutable std::vector<float>              m_2hitDeltaPHVec;
-    mutable std::vector<float>              m_2hitSumPHVec;
+    mutable std::vector<float> m_deltaTimeVec;
+    mutable std::vector<float> m_deltaTime0Vec;
+    mutable std::vector<float> m_deltaSigma0Vec;
+    mutable std::vector<float> m_deltaTime1Vec;
+    mutable std::vector<float> m_deltaSigma1Vec;
+    mutable std::vector<float> m_deltaTime2Vec;
+    mutable std::vector<float> m_deltaSigma2Vec;
+    mutable std::vector<float> m_chiSquare3DVec;
+    mutable std::vector<float> m_maxPullVec;
+    mutable std::vector<float> m_overlapFractionVec;
+    mutable std::vector<float> m_overlapRangeVec;
+    mutable std::vector<float> m_maxDeltaPeakVec;
+    mutable std::vector<float> m_maxSideVecVec;
+    mutable std::vector<float> m_pairWireDistVec;
+    mutable std::vector<float> m_smallChargeDiffVec;
+    mutable std::vector<int> m_smallIndexVec;
+    mutable std::vector<float> m_qualityMetricVec;
+    mutable std::vector<float> m_spacePointChargeVec;
+    mutable std::vector<float> m_hitAsymmetryVec;
+    mutable std::vector<float> m_2hit1stPHVec;
+    mutable std::vector<float> m_2hit2ndPHVec;
+    mutable std::vector<float> m_2hitDeltaPHVec;
+    mutable std::vector<float> m_2hitSumPHVec;
 
     // Get instances of the primary data structures needed
-    mutable Hit2DList                       m_clusterHit2DMasterList;
-    mutable PlaneToSnippetHitMap            m_planeToSnippetHitMap;
-    mutable PlaneToWireToHitSetMap          m_planeToWireToHitSetMap;
+    mutable Hit2DList m_clusterHit2DMasterList;
+    mutable PlaneToSnippetHitMap m_planeToSnippetHitMap;
+    mutable PlaneToWireToHitSetMap m_planeToWireToHitSetMap;
 
-    mutable bool                            m_weHaveAllBeenHereBefore = false;
+    mutable bool m_weHaveAllBeenHereBefore = false;
 
-    const geo::Geometry*                    m_geometry;              //< pointer to the Geometry service
-    const geo::WireReadoutGeom*             m_wireReadoutAlg;        //< The new wire readout service
-    const lariov::ChannelStatusProvider*    m_channelFilter;
-};
+    const geo::Geometry* m_geometry;              //< pointer to the Geometry service
+    const geo::WireReadoutGeom* m_wireReadoutAlg; //< The new wire readout service
+    const lariov::ChannelStatusProvider* m_channelFilter;
+  };
 
-SnippetHit3DBuilder::SnippetHit3DBuilder(fhicl::ParameterSet const &pset) :
-    m_channelFilter(&art::ServiceHandle<lariov::ChannelStatusService const>()->GetProvider())
+  SnippetHit3DBuilder::SnippetHit3DBuilder(fhicl::ParameterSet const& pset)
+    : m_channelFilter(&art::ServiceHandle<lariov::ChannelStatusService const>()->GetProvider())
 
-{
+  {
     this->configure(pset);
-}
+  }
 
-//------------------------------------------------------------------------------------------------------------------------------------------
+  //------------------------------------------------------------------------------------------------------------------------------------------
 
-void SnippetHit3DBuilder::produces(art::ProducesCollector& collector)
-{
-    collector.produces< std::vector<recob::Hit>>();
-    collector.produces< art::Assns<recob::Wire,   recob::Hit>>();
-    collector.produces< art::Assns<raw::RawDigit, recob::Hit>>();
-}
+  void SnippetHit3DBuilder::produces(art::ProducesCollector& collector)
+  {
+    collector.produces<std::vector<recob::Hit>>();
+    collector.produces<art::Assns<recob::Wire, recob::Hit>>();
+    collector.produces<art::Assns<raw::RawDigit, recob::Hit>>();
+  }
 
-//------------------------------------------------------------------------------------------------------------------------------------------
+  //------------------------------------------------------------------------------------------------------------------------------------------
 
-void SnippetHit3DBuilder::configure(fhicl::ParameterSet const &pset)
-{
-    m_hitFinderTagVec      = pset.get<std::vector<art::InputTag>>("HitFinderTagVec",        {"gaushit"});
-    m_enableMonitoring     = pset.get<bool                      >("EnableMonitoring",       true);
-    m_hitWidthSclFctr      = pset.get<float                     >("HitWidthScaleFactor",    6.  );
-    m_rangeNumSig          = pset.get<float                     >("RangeNumSigma",          3.  );
-    m_LongHitStretchFctr   = pset.get<float                     >("LongHitsStretchFactor",  1.5 );
-    m_pulseHeightFrac      = pset.get<float                     >("PulseHeightFraction",    0.5 );
-    m_PHLowSelection       = pset.get<float                     >("PHLowSelection",         20. );
-    m_minPHFor2HitPoints   = pset.get<float                     >("MinPHFor2HitPoints",     15. );
-    m_deltaPeakTimeSig     = pset.get<float                     >("DeltaPeakTimeSig",       1.7 );
-    m_zPosOffset           = pset.get<float                     >("ZPosOffset",             0.0 );
-    m_invalidTPCVec        = pset.get<std::vector<int>          >("InvalidTPCVec",          std::vector<int>());
-    m_wirePitchScaleFactor = pset.get<float                     >("WirePitchScaleFactor",   1.9 );
-    m_maxHit3DChiSquare    = pset.get<float                     >("MaxHitChiSquare",        6.0 );
-    m_saveBadChannelPairs  = pset.get<bool                      >("SaveBadChannelPairs",    true);
-    m_saveMythicalPoints   = pset.get<bool                      >("SaveMythicalPoints",     true);
-    m_maxMythicalChiSquare = pset.get<float                     >("MaxMythicalChiSquare",    10.);
-    m_useT0Offsets         = pset.get<bool                      >("UseT0Offsets",           true);
-    m_outputHistograms     = pset.get<bool                      >("OutputHistograms",      false);
-    m_makeAssociations     = pset.get<bool                      >("MakeAssociations",      false);
+  void SnippetHit3DBuilder::configure(fhicl::ParameterSet const& pset)
+  {
+    m_hitFinderTagVec = pset.get<std::vector<art::InputTag>>("HitFinderTagVec", {"gaushit"});
+    m_enableMonitoring = pset.get<bool>("EnableMonitoring", true);
+    m_hitWidthSclFctr = pset.get<float>("HitWidthScaleFactor", 6.);
+    m_rangeNumSig = pset.get<float>("RangeNumSigma", 3.);
+    m_LongHitStretchFctr = pset.get<float>("LongHitsStretchFactor", 1.5);
+    m_pulseHeightFrac = pset.get<float>("PulseHeightFraction", 0.5);
+    m_PHLowSelection = pset.get<float>("PHLowSelection", 20.);
+    m_minPHFor2HitPoints = pset.get<float>("MinPHFor2HitPoints", 15.);
+    m_deltaPeakTimeSig = pset.get<float>("DeltaPeakTimeSig", 1.7);
+    m_zPosOffset = pset.get<float>("ZPosOffset", 0.0);
+    m_invalidTPCVec = pset.get<std::vector<int>>("InvalidTPCVec", std::vector<int>());
+    m_wirePitchScaleFactor = pset.get<float>("WirePitchScaleFactor", 1.9);
+    m_maxHit3DChiSquare = pset.get<float>("MaxHitChiSquare", 6.0);
+    m_saveBadChannelPairs = pset.get<bool>("SaveBadChannelPairs", true);
+    m_saveMythicalPoints = pset.get<bool>("SaveMythicalPoints", true);
+    m_maxMythicalChiSquare = pset.get<float>("MaxMythicalChiSquare", 10.);
+    m_useT0Offsets = pset.get<bool>("UseT0Offsets", true);
+    m_outputHistograms = pset.get<bool>("OutputHistograms", false);
+    m_makeAssociations = pset.get<bool>("MakeAssociations", false);
 
     m_geometry = art::ServiceHandle<geo::Geometry const>{}.get();
-    m_wireReadoutAlg = &art::ServiceHandle<geo::WireReadout const>{}->Get();
+    m_wireReadoutAlg = &art::ServiceHandle<geo::WireReadout const>
+    {
+      } -> Get();
 
     // Returns the wire pitch per plane assuming they will be the same for all TPCs
     constexpr geo::TPCID tpcid{0, 0};
@@ -370,53 +401,51 @@ void SnippetHit3DBuilder::configure(fhicl::ParameterSet const &pset)
 
     // Access ART's TFileService, which will handle creating and writing
     // histograms and n-tuples for us.
-    if (m_outputHistograms)
-    {
-        art::ServiceHandle<art::TFileService> tfs;
+    if (m_outputHistograms) {
+      art::ServiceHandle<art::TFileService> tfs;
 
-        m_tupleTree = tfs->make<TTree>("Hit3DBuilderTree", "Tree by SnippetHit3DBuilder");
+      m_tupleTree = tfs->make<TTree>("Hit3DBuilderTree", "Tree by SnippetHit3DBuilder");
 
-        clear();
+      clear();
 
-        m_tupleTree->Branch("DeltaPeakTimePair0",  "std::vector<float>", &m_deltaPeakTimePlane0Vec);
-        m_tupleTree->Branch("DeltaPeakSigmaPair0", "std::vector<float>", &m_deltaPeakSigmaPlane0Vec);
-        m_tupleTree->Branch("DeltaPeakTimePair1",  "std::vector<float>", &m_deltaPeakTimePlane1Vec);
-        m_tupleTree->Branch("DeltaPeakSigmaPair1", "std::vector<float>", &m_deltaPeakSigmaPlane1Vec);
-        m_tupleTree->Branch("DeltaPeakTimePair2",  "std::vector<float>", &m_deltaPeakTimePlane2Vec);
-        m_tupleTree->Branch("DeltaPeakSigmaPair2", "std::vector<float>", &m_deltaPeakSigmaPlane2Vec);
+      m_tupleTree->Branch("DeltaPeakTimePair0", "std::vector<float>", &m_deltaPeakTimePlane0Vec);
+      m_tupleTree->Branch("DeltaPeakSigmaPair0", "std::vector<float>", &m_deltaPeakSigmaPlane0Vec);
+      m_tupleTree->Branch("DeltaPeakTimePair1", "std::vector<float>", &m_deltaPeakTimePlane1Vec);
+      m_tupleTree->Branch("DeltaPeakSigmaPair1", "std::vector<float>", &m_deltaPeakSigmaPlane1Vec);
+      m_tupleTree->Branch("DeltaPeakTimePair2", "std::vector<float>", &m_deltaPeakTimePlane2Vec);
+      m_tupleTree->Branch("DeltaPeakSigmaPair2", "std::vector<float>", &m_deltaPeakSigmaPlane2Vec);
 
-        m_tupleTree->Branch("DeltaTime2D",     "std::vector<float>", &m_deltaTimeVec);
-        m_tupleTree->Branch("DeltaTime2D0",    "std::vector<float>", &m_deltaTime0Vec);
-        m_tupleTree->Branch("DeltaSigma2D0",   "std::vector<float>", &m_deltaSigma0Vec);
-        m_tupleTree->Branch("DeltaTime2D1",    "std::vector<float>", &m_deltaTime1Vec);
-        m_tupleTree->Branch("DeltaSigma2D1",   "std::vector<float>", &m_deltaSigma1Vec);
-        m_tupleTree->Branch("DeltaTime2D2",    "std::vector<float>", &m_deltaTime2Vec);
-        m_tupleTree->Branch("DeltaSigma2D2",   "std::vector<float>", &m_deltaSigma2Vec);
-        m_tupleTree->Branch("ChiSquare3D",     "std::vector<float>", &m_chiSquare3DVec);
-        m_tupleTree->Branch("MaxPullValue",    "std::vector<float>", &m_maxPullVec);
-        m_tupleTree->Branch("OverlapFraction", "std::vector<float>", &m_overlapFractionVec);
-        m_tupleTree->Branch("OverlapRange",    "std::vector<float>", &m_overlapRangeVec);
-        m_tupleTree->Branch("MaxDeltaPeak",    "std::vector<float>", &m_maxDeltaPeakVec);
-        m_tupleTree->Branch("MaxSideVec",      "std::vector<float>", &m_maxSideVecVec);
-        m_tupleTree->Branch("PairWireDistVec", "std::vector<float>", &m_pairWireDistVec);
-        m_tupleTree->Branch("SmallChargeDiff", "std::vector<float>", &m_smallChargeDiffVec);
-        m_tupleTree->Branch("SmallChargeIdx",  "std::vector<int>",   &m_smallIndexVec);
-        m_tupleTree->Branch("QualityMetric",   "std::vector<float>", &m_qualityMetricVec);
-        m_tupleTree->Branch("SPCharge",        "std::vector<float>", &m_spacePointChargeVec);
-        m_tupleTree->Branch("HitAsymmetry",    "std::vector<float>", &m_hitAsymmetryVec);
+      m_tupleTree->Branch("DeltaTime2D", "std::vector<float>", &m_deltaTimeVec);
+      m_tupleTree->Branch("DeltaTime2D0", "std::vector<float>", &m_deltaTime0Vec);
+      m_tupleTree->Branch("DeltaSigma2D0", "std::vector<float>", &m_deltaSigma0Vec);
+      m_tupleTree->Branch("DeltaTime2D1", "std::vector<float>", &m_deltaTime1Vec);
+      m_tupleTree->Branch("DeltaSigma2D1", "std::vector<float>", &m_deltaSigma1Vec);
+      m_tupleTree->Branch("DeltaTime2D2", "std::vector<float>", &m_deltaTime2Vec);
+      m_tupleTree->Branch("DeltaSigma2D2", "std::vector<float>", &m_deltaSigma2Vec);
+      m_tupleTree->Branch("ChiSquare3D", "std::vector<float>", &m_chiSquare3DVec);
+      m_tupleTree->Branch("MaxPullValue", "std::vector<float>", &m_maxPullVec);
+      m_tupleTree->Branch("OverlapFraction", "std::vector<float>", &m_overlapFractionVec);
+      m_tupleTree->Branch("OverlapRange", "std::vector<float>", &m_overlapRangeVec);
+      m_tupleTree->Branch("MaxDeltaPeak", "std::vector<float>", &m_maxDeltaPeakVec);
+      m_tupleTree->Branch("MaxSideVec", "std::vector<float>", &m_maxSideVecVec);
+      m_tupleTree->Branch("PairWireDistVec", "std::vector<float>", &m_pairWireDistVec);
+      m_tupleTree->Branch("SmallChargeDiff", "std::vector<float>", &m_smallChargeDiffVec);
+      m_tupleTree->Branch("SmallChargeIdx", "std::vector<int>", &m_smallIndexVec);
+      m_tupleTree->Branch("QualityMetric", "std::vector<float>", &m_qualityMetricVec);
+      m_tupleTree->Branch("SPCharge", "std::vector<float>", &m_spacePointChargeVec);
+      m_tupleTree->Branch("HitAsymmetry", "std::vector<float>", &m_hitAsymmetryVec);
 
-        m_tupleTree->Branch("2hit1stPH",       "std::vector<float>", &m_2hit1stPHVec);
-        m_tupleTree->Branch("2hit2ndPH",       "std::vector<float>", &m_2hit2ndPHVec);
-        m_tupleTree->Branch("2hitDeltaPH",     "std::vector<float>", &m_2hitDeltaPHVec);
-        m_tupleTree->Branch("2hitSumPH",       "std::vector<float>", &m_2hitSumPHVec);
-
+      m_tupleTree->Branch("2hit1stPH", "std::vector<float>", &m_2hit1stPHVec);
+      m_tupleTree->Branch("2hit2ndPH", "std::vector<float>", &m_2hit2ndPHVec);
+      m_tupleTree->Branch("2hitDeltaPH", "std::vector<float>", &m_2hitDeltaPHVec);
+      m_tupleTree->Branch("2hitSumPH", "std::vector<float>", &m_2hitSumPHVec);
     }
 
     return;
-}
+  }
 
-void SnippetHit3DBuilder::clear()
-{
+  void SnippetHit3DBuilder::clear()
+  {
     m_deltaPeakTimePlane0Vec.clear();
     m_deltaPeakSigmaPlane0Vec.clear();
     m_deltaPeakTimePlane1Vec.clear();
@@ -450,27 +479,29 @@ void SnippetHit3DBuilder::clear()
     m_2hitSumPHVec.clear();
 
     return;
-}
+  }
 
-bool SetPeakHitPairIteratorOrder(const reco::HitPairList::iterator& left, const reco::HitPairList::iterator& right)
-{
+  bool SetPeakHitPairIteratorOrder(const reco::HitPairList::iterator& left,
+                                   const reco::HitPairList::iterator& right)
+  {
     return (*left).getAvePeakTime() < (*right).getAvePeakTime();
-}
+  }
 
-struct HitPairClusterOrder
-{
-    bool operator()(const reco::HitPairClusterMap::iterator& left, const reco::HitPairClusterMap::iterator& right)
+  struct HitPairClusterOrder {
+    bool operator()(const reco::HitPairClusterMap::iterator& left,
+                    const reco::HitPairClusterMap::iterator& right)
     {
-        // Watch out for the case where two clusters can have the same number of hits!
-        if (left->second.size() == right->second.size())
-            return left->first < right->first;
+      // Watch out for the case where two clusters can have the same number of hits!
+      if (left->second.size() == right->second.size()) return left->first < right->first;
 
-        return left->second.size() > right->second.size();
+      return left->second.size() > right->second.size();
     }
-};
+  };
 
-void SnippetHit3DBuilder::Hit3DBuilder(art::Event& evt, reco::HitPairList& hitPairList, RecobHitToPtrMap& clusterHitToArtPtrMap)
-{
+  void SnippetHit3DBuilder::Hit3DBuilder(art::Event& evt,
+                                         reco::HitPairList& hitPairList,
+                                         RecobHitToPtrMap& clusterHitToArtPtrMap)
+  {
     // Clear the internal data structures
     m_clusterHit2DMasterList.clear();
     m_planeToSnippetHitMap.clear();
@@ -479,26 +510,28 @@ void SnippetHit3DBuilder::Hit3DBuilder(art::Event& evt, reco::HitPairList& hitPa
     mf::LogDebug("SnippetHit3D") << "SnippetHit3DBuilder entered" << std::endl;
 
     // Do the one time initialization of the tick offsets.
-    if (m_PlaneToT0OffsetMap.empty())
-    {
-        // Need the detector properties which needs the clocks
-        auto const clock_data = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
-        auto const det_prop   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clock_data);
+    if (m_PlaneToT0OffsetMap.empty()) {
+      // Need the detector properties which needs the clocks
+      auto const clock_data =
+        art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+      auto const det_prop =
+        art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clock_data);
 
-        // Initialize the plane to hit vector map
-        for(size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++)
-        {
-            for(size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++)
-            {
-                for(size_t planeIdx = 0; planeIdx < m_wireReadoutAlg->Nplanes(); planeIdx++)
-                {
-                    geo::PlaneID planeID(cryoIdx,tpcIdx,planeIdx);
+      // Initialize the plane to hit vector map
+      for (size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++) {
+        for (size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++) {
+          for (size_t planeIdx = 0; planeIdx < m_wireReadoutAlg->Nplanes(); planeIdx++) {
+            geo::PlaneID planeID(cryoIdx, tpcIdx, planeIdx);
 
-                    if (m_useT0Offsets) m_PlaneToT0OffsetMap[planeID] = det_prop.GetXTicksOffset(planeID) - det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,0));
-                    else                m_PlaneToT0OffsetMap[planeID] = 0.;
-                }
-            }
+            if (m_useT0Offsets)
+              m_PlaneToT0OffsetMap[planeID] =
+                det_prop.GetXTicksOffset(planeID) -
+                det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 0));
+            else
+              m_PlaneToT0OffsetMap[planeID] = 0.;
+          }
         }
+      }
     }
 
     m_timeVector.resize(NUMTIMEVALUES, 0.);
@@ -513,24 +546,25 @@ void SnippetHit3DBuilder::Hit3DBuilder(art::Event& evt, reco::HitPairList& hitPa
     mf::LogDebug("SnippetHit3D") << "SnippetHit3DBuilder building space points";
 
     // If there are no hits in our view/wire data structure then do not proceed with the full analysis
-    if (!m_planeToWireToHitSetMap.empty())
-    {
-        // Call the algorithm that builds 3D hits
-        this->BuildHit3D(hitPairList);
+    if (!m_planeToWireToHitSetMap.empty()) {
+      // Call the algorithm that builds 3D hits
+      this->BuildHit3D(hitPairList);
 
-        // If we built 3D points then attempt to output a new hit list as well
-        if (!hitPairList.empty())
-            CreateNewRecobHitCollection(evt, hitPairList, *outputHitPtrVec, clusterHitToArtPtrMap);
+      // If we built 3D points then attempt to output a new hit list as well
+      if (!hitPairList.empty())
+        CreateNewRecobHitCollection(evt, hitPairList, *outputHitPtrVec, clusterHitToArtPtrMap);
     }
 
     // Set up to make the associations (if desired)
     /// Associations with wires.
-    std::unique_ptr<art::Assns<recob::Wire, recob::Hit>> wireAssns(new art::Assns<recob::Wire, recob::Hit>);
+    std::unique_ptr<art::Assns<recob::Wire, recob::Hit>> wireAssns(
+      new art::Assns<recob::Wire, recob::Hit>);
 
     if (m_makeAssociations) makeWireAssns(evt, *wireAssns, clusterHitToArtPtrMap);
 
     /// Associations with raw digits.
-    std::unique_ptr<art::Assns<raw::RawDigit, recob::Hit>> rawDigitAssns(new art::Assns<raw::RawDigit, recob::Hit>);
+    std::unique_ptr<art::Assns<raw::RawDigit, recob::Hit>> rawDigitAssns(
+      new art::Assns<raw::RawDigit, recob::Hit>);
 
     if (m_makeAssociations) makeRawDigitAssns(evt, *rawDigitAssns, clusterHitToArtPtrMap);
 
@@ -540,20 +574,19 @@ void SnippetHit3DBuilder::Hit3DBuilder(art::Event& evt, reco::HitPairList& hitPa
     evt.put(std::move(rawDigitAssns));
 
     // Handle tree output too
-    if (m_outputHistograms)
-    {
-        m_tupleTree->Fill();
+    if (m_outputHistograms) {
+      m_tupleTree->Fill();
 
-        clear();
+      clear();
     }
 
     mf::LogDebug("SnippetHit3D") << "SnippetHit3DBuilder exited";
 
     return;
-}
+  }
 
-void SnippetHit3DBuilder::BuildHit3D(reco::HitPairList& hitPairList) const
-{
+  void SnippetHit3DBuilder::BuildHit3D(reco::HitPairList& hitPairList) const
+  {
     /**
      *  @brief Driver for processing input 2D hits, transforming to 3D hits and building lists
      *         of associated 3D hits (candidate 3D clusters)
@@ -564,48 +597,48 @@ void SnippetHit3DBuilder::BuildHit3D(reco::HitPairList& hitPairList) const
 
     size_t numHitPairs = BuildHitPairMap(m_planeToSnippetHitMap, hitPairList);
 
-    if (m_enableMonitoring)
-    {
-        theClockMakeHits.stop();
+    if (m_enableMonitoring) {
+      theClockMakeHits.stop();
 
-        m_timeVector[BUILDTHREEDHITS] = theClockMakeHits.accumulated_real_time();
+      m_timeVector[BUILDTHREEDHITS] = theClockMakeHits.accumulated_real_time();
     }
 
-    mf::LogDebug("SnippetHit3D") << ">>>>> 3D hit building done, found " << numHitPairs << " 3D Hits" << std::endl;
+    mf::LogDebug("SnippetHit3D") << ">>>>> 3D hit building done, found " << numHitPairs
+                                 << " 3D Hits" << std::endl;
 
     return;
-}
+  }
 
-//------------------------------------------------------------------------------------------------------------------------------------------
-class SetStartTimeOrder
-{
-public:
+  //------------------------------------------------------------------------------------------------------------------------------------------
+  class SetStartTimeOrder {
+  public:
     SetStartTimeOrder() {}
 
     bool operator()(const SnippetHitMapItrPair& left, const SnippetHitMapItrPair& right) const
     {
-        // Special case handling, there is nothing to compare for the left or right
-        if (left.first  == left.second)  return false;
-        if (right.first == right.second) return true;
+      // Special case handling, there is nothing to compare for the left or right
+      if (left.first == left.second) return false;
+      if (right.first == right.second) return true;
 
-        // de-referencing a bunch of pairs here...
-        return left.first->first.first < right.first->first.first;
+      // de-referencing a bunch of pairs here...
+      return left.first->first.first < right.first->first.first;
     }
 
-private:
-};
+  private:
+  };
 
-bool SetPairStartTimeOrder(const reco::ClusterHit3D& left, const reco::ClusterHit3D& right)
-{
+  bool SetPairStartTimeOrder(const reco::ClusterHit3D& left, const reco::ClusterHit3D& right)
+  {
     // Sort by "modified start time" of pulse
-    return left.getAvePeakTime() - left.getSigmaPeakTime() < right.getAvePeakTime() - right.getSigmaPeakTime();
-}
+    return left.getAvePeakTime() - left.getSigmaPeakTime() <
+           right.getAvePeakTime() - right.getSigmaPeakTime();
+  }
 
+  //------------------------------------------------------------------------------------------------------------------------------------------
 
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-size_t SnippetHit3DBuilder::BuildHitPairMap(PlaneToSnippetHitMap& planeToSnippetHitMap, reco::HitPairList& hitPairList) const
-{
+  size_t SnippetHit3DBuilder::BuildHitPairMap(PlaneToSnippetHitMap& planeToSnippetHitMap,
+                                              reco::HitPairList& hitPairList) const
+  {
     /**
      *  @brief Given input 2D hits, build out the lists of possible 3D hits
      *
@@ -621,34 +654,37 @@ size_t SnippetHit3DBuilder::BuildHitPairMap(PlaneToSnippetHitMap& planeToSnippet
     size_t nTriplets(0);
 
     // Set up to loop over cryostats and tpcs...
-    for(size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++)
-    {
-        for(size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++)
-        {
-            //************************************
-            // Kludge
-//            if (!(cryoIdx == 1 && tpcIdx == 0)) continue;
+    for (size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++) {
+      for (size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++) {
+        //************************************
+        // Kludge
+        //            if (!(cryoIdx == 1 && tpcIdx == 0)) continue;
 
-            PlaneToSnippetHitMap::iterator mapItr0 = planeToSnippetHitMap.find(geo::PlaneID(cryoIdx,tpcIdx,0));
-            PlaneToSnippetHitMap::iterator mapItr1 = planeToSnippetHitMap.find(geo::PlaneID(cryoIdx,tpcIdx,1));
-            PlaneToSnippetHitMap::iterator mapItr2 = planeToSnippetHitMap.find(geo::PlaneID(cryoIdx,tpcIdx,2));
+        PlaneToSnippetHitMap::iterator mapItr0 =
+          planeToSnippetHitMap.find(geo::PlaneID(cryoIdx, tpcIdx, 0));
+        PlaneToSnippetHitMap::iterator mapItr1 =
+          planeToSnippetHitMap.find(geo::PlaneID(cryoIdx, tpcIdx, 1));
+        PlaneToSnippetHitMap::iterator mapItr2 =
+          planeToSnippetHitMap.find(geo::PlaneID(cryoIdx, tpcIdx, 2));
 
-            size_t nPlanesWithHits = (mapItr0 != planeToSnippetHitMap.end() && !mapItr0->second.empty() ? 1 : 0)
-                                   + (mapItr1 != planeToSnippetHitMap.end() && !mapItr1->second.empty() ? 1 : 0)
-                                   + (mapItr2 != planeToSnippetHitMap.end() && !mapItr2->second.empty() ? 1 : 0);
+        size_t nPlanesWithHits =
+          (mapItr0 != planeToSnippetHitMap.end() && !mapItr0->second.empty() ? 1 : 0) +
+          (mapItr1 != planeToSnippetHitMap.end() && !mapItr1->second.empty() ? 1 : 0) +
+          (mapItr2 != planeToSnippetHitMap.end() && !mapItr2->second.empty() ? 1 : 0);
 
-            if (nPlanesWithHits < 2) continue;
+        if (nPlanesWithHits < 2) continue;
 
-            SnippetHitMap& snippetHitMap0 = mapItr0->second;
-            SnippetHitMap& snippetHitMap1 = mapItr1->second;
-            SnippetHitMap& snippetHitMap2 = mapItr2->second;
+        SnippetHitMap& snippetHitMap0 = mapItr0->second;
+        SnippetHitMap& snippetHitMap1 = mapItr1->second;
+        SnippetHitMap& snippetHitMap2 = mapItr2->second;
 
-            PlaneSnippetHitMapItrPairVec hitItrVec = {SnippetHitMapItrPair(snippetHitMap0.begin(),snippetHitMap0.end()),
-                                                      SnippetHitMapItrPair(snippetHitMap1.begin(),snippetHitMap1.end()),
-                                                      SnippetHitMapItrPair(snippetHitMap2.begin(),snippetHitMap2.end())};
+        PlaneSnippetHitMapItrPairVec hitItrVec = {
+          SnippetHitMapItrPair(snippetHitMap0.begin(), snippetHitMap0.end()),
+          SnippetHitMapItrPair(snippetHitMap1.begin(), snippetHitMap1.end()),
+          SnippetHitMapItrPair(snippetHitMap2.begin(), snippetHitMap2.end())};
 
-            totalNumHits += BuildHitPairMapByTPC(hitItrVec, hitPairList);
-        }
+        totalNumHits += BuildHitPairMapByTPC(hitItrVec, hitPairList);
+      }
     }
 
     // Return the hit pair list but sorted by z and y positions (faster traversal in next steps)
@@ -656,14 +692,17 @@ size_t SnippetHit3DBuilder::BuildHitPairMap(PlaneToSnippetHitMap& planeToSnippet
 
     // Where are we?
     mf::LogDebug("SnippetHit3D") << "Total number hits: " << totalNumHits << std::endl;
-    mf::LogDebug("SnippetHit3D") << "Created a total of " << hitPairList.size() << " hit pairs, counted: " << hitPairCntr << std::endl;
+    mf::LogDebug("SnippetHit3D") << "Created a total of " << hitPairList.size()
+                                 << " hit pairs, counted: " << hitPairCntr << std::endl;
     mf::LogDebug("SnippetHit3D") << "-- Triplets: " << nTriplets << std::endl;
 
     return hitPairList.size();
-}
+  }
 
-size_t SnippetHit3DBuilder::BuildHitPairMapByTPC(PlaneSnippetHitMapItrPairVec& snippetHitMapItrVec, reco::HitPairList& hitPairList) const
-{
+  size_t SnippetHit3DBuilder::BuildHitPairMapByTPC(
+    PlaneSnippetHitMapItrPairVec& snippetHitMapItrVec,
+    reco::HitPairList& hitPairList) const
+  {
     /**
      *  @brief Given input 2D hits, build out the lists of possible 3D hits
      *
@@ -675,25 +714,27 @@ size_t SnippetHit3DBuilder::BuildHitPairMapByTPC(PlaneSnippetHitMapItrPairVec& s
      */
 
     // Define functions to set start/end iterators in the loop below
-    auto SetStartIterator = [](SnippetHitMap::iterator startItr, SnippetHitMap::iterator endItr, float startTime)
-    {
-        while(startItr != endItr)
-        {
-            if (startItr->first.second < startTime) startItr++;
-            else break;
+    auto SetStartIterator =
+      [](SnippetHitMap::iterator startItr, SnippetHitMap::iterator endItr, float startTime) {
+        while (startItr != endItr) {
+          if (startItr->first.second < startTime)
+            startItr++;
+          else
+            break;
         }
         return startItr;
-    };
+      };
 
-    auto SetEndIterator = [](SnippetHitMap::iterator lastItr, SnippetHitMap::iterator endItr, float endTime)
-    {
-        while(lastItr != endItr)
-        {
-            if (lastItr->first.first < endTime) lastItr++;
-            else break;
+    auto SetEndIterator =
+      [](SnippetHitMap::iterator lastItr, SnippetHitMap::iterator endItr, float endTime) {
+        while (lastItr != endItr) {
+          if (lastItr->first.first < endTime)
+            lastItr++;
+          else
+            break;
         }
         return lastItr;
-    };
+      };
 
     size_t nTriplets(0);
     size_t nOrphanPairs(0);
@@ -703,354 +744,375 @@ size_t SnippetHit3DBuilder::BuildHitPairMapByTPC(PlaneSnippetHitMapItrPairVec& s
 
     //*********************************************************************************
     // Basically, we try to loop until done...
-    while(1)
-    {
-        // Sort so that the earliest hit time will be the first element, etc.
-        std::sort(snippetHitMapItrVec.begin(),snippetHitMapItrVec.end(),SetStartTimeOrder());
+    while (1) {
+      // Sort so that the earliest hit time will be the first element, etc.
+      std::sort(snippetHitMapItrVec.begin(), snippetHitMapItrVec.end(), SetStartTimeOrder());
 
-        // Make sure there are still hits on at least
-        int nPlanesWithHits(0);
+      // Make sure there are still hits on at least
+      int nPlanesWithHits(0);
 
-        for(auto& pair : snippetHitMapItrVec)
-            if (pair.first != pair.second) nPlanesWithHits++;
+      for (auto& pair : snippetHitMapItrVec)
+        if (pair.first != pair.second) nPlanesWithHits++;
 
-        if (nPlanesWithHits < 2) break;
+      if (nPlanesWithHits < 2) break;
 
-        // End condition: no more hit snippets
-//        if (snippetHitMapItrVec.front().first == snippetHitMapItrVec.front().second) break;
+      // End condition: no more hit snippets
+      //        if (snippetHitMapItrVec.front().first == snippetHitMapItrVec.front().second) break;
 
-        // This loop iteration's snippet iterator
-        SnippetHitMap::iterator firstSnippetItr = snippetHitMapItrVec.front().first;
+      // This loop iteration's snippet iterator
+      SnippetHitMap::iterator firstSnippetItr = snippetHitMapItrVec.front().first;
 
-        // Set iterators to insure we'll be in the overlap ranges
-        SnippetHitMap::iterator snippetHitMapItr1Start = SetStartIterator(snippetHitMapItrVec[1].first, snippetHitMapItrVec[1].second, firstSnippetItr->first.first);
-        SnippetHitMap::iterator snippetHitMapItr1End   = SetEndIterator( snippetHitMapItr1Start,        snippetHitMapItrVec[1].second, firstSnippetItr->first.second);
-        SnippetHitMap::iterator snippetHitMapItr2Start = SetStartIterator(snippetHitMapItrVec[2].first, snippetHitMapItrVec[2].second, firstSnippetItr->first.first);
-        SnippetHitMap::iterator snippetHitMapItr2End   = SetEndIterator( snippetHitMapItr2Start,        snippetHitMapItrVec[2].second, firstSnippetItr->first.second);
+      // Set iterators to insure we'll be in the overlap ranges
+      SnippetHitMap::iterator snippetHitMapItr1Start = SetStartIterator(
+        snippetHitMapItrVec[1].first, snippetHitMapItrVec[1].second, firstSnippetItr->first.first);
+      SnippetHitMap::iterator snippetHitMapItr1End = SetEndIterator(
+        snippetHitMapItr1Start, snippetHitMapItrVec[1].second, firstSnippetItr->first.second);
+      SnippetHitMap::iterator snippetHitMapItr2Start = SetStartIterator(
+        snippetHitMapItrVec[2].first, snippetHitMapItrVec[2].second, firstSnippetItr->first.first);
+      SnippetHitMap::iterator snippetHitMapItr2End = SetEndIterator(
+        snippetHitMapItr2Start, snippetHitMapItrVec[2].second, firstSnippetItr->first.second);
 
-        // Since we'll use these many times in the internal loops, pre make the pairs for the second set of hits
-        size_t                curHitListSize(hitPairList.size());
-        HitMatchTripletVecMap pair12Map;
-        HitMatchTripletVecMap pair13Map;
+      // Since we'll use these many times in the internal loops, pre make the pairs for the second set of hits
+      size_t curHitListSize(hitPairList.size());
+      HitMatchTripletVecMap pair12Map;
+      HitMatchTripletVecMap pair13Map;
 
-        size_t n12Pairs = findGoodHitPairs(firstSnippetItr, snippetHitMapItr1Start, snippetHitMapItr1End, pair12Map);
-        size_t n13Pairs = findGoodHitPairs(firstSnippetItr, snippetHitMapItr2Start, snippetHitMapItr2End, pair13Map);
+      size_t n12Pairs =
+        findGoodHitPairs(firstSnippetItr, snippetHitMapItr1Start, snippetHitMapItr1End, pair12Map);
+      size_t n13Pairs =
+        findGoodHitPairs(firstSnippetItr, snippetHitMapItr2Start, snippetHitMapItr2End, pair13Map);
 
-        curHitListSize  = hitPairList.size();
+      curHitListSize = hitPairList.size();
 
-        if (n12Pairs > n13Pairs) findGoodTriplets(pair12Map, pair13Map, matchedHitMap, hitPairList);
-        else                     findGoodTriplets(pair13Map, pair12Map, matchedHitMap, hitPairList);
+      if (n12Pairs > n13Pairs)
+        findGoodTriplets(pair12Map, pair13Map, matchedHitMap, hitPairList);
+      else
+        findGoodTriplets(pair13Map, pair12Map, matchedHitMap, hitPairList);
 
-        if (m_saveBadChannelPairs)
-        {
-            nOrphanPairs += saveBadChannelPairs(pair12Map, matchedHitMap, hitPairList);
-            nOrphanPairs += saveBadChannelPairs(pair13Map, matchedHitMap, hitPairList);
-        }
+      if (m_saveBadChannelPairs) {
+        nOrphanPairs += saveBadChannelPairs(pair12Map, matchedHitMap, hitPairList);
+        nOrphanPairs += saveBadChannelPairs(pair13Map, matchedHitMap, hitPairList);
+      }
 
-        if (m_saveMythicalPoints)
-        {
-            nOrphanPairs += saveOrphanPairs(pair12Map, matchedHitMap, hitPairList);
-            nOrphanPairs += saveOrphanPairs(pair13Map, matchedHitMap, hitPairList);
-        }
+      if (m_saveMythicalPoints) {
+        nOrphanPairs += saveOrphanPairs(pair12Map, matchedHitMap, hitPairList);
+        nOrphanPairs += saveOrphanPairs(pair13Map, matchedHitMap, hitPairList);
+      }
 
-        nTriplets += hitPairList.size() - curHitListSize;
+      nTriplets += hitPairList.size() - curHitListSize;
 
-        snippetHitMapItrVec.front().first++;
+      snippetHitMapItrVec.front().first++;
     }
 
-    mf::LogDebug("SnippetHit3D") << "--> Created " << nTriplets << " triplets of which " << nOrphanPairs << " are orphans" << std::endl;
+    mf::LogDebug("SnippetHit3D") << "--> Created " << nTriplets << " triplets of which "
+                                 << nOrphanPairs << " are orphans" << std::endl;
 
     return hitPairList.size();
-}
+  }
 
-int SnippetHit3DBuilder::findGoodHitPairs(SnippetHitMap::iterator& firstSnippetItr,
-                                             SnippetHitMap::iterator& startItr,
-                                             SnippetHitMap::iterator& endItr,
-                                             HitMatchTripletVecMap&   hitMatchMap) const
-{
+  int SnippetHit3DBuilder::findGoodHitPairs(SnippetHitMap::iterator& firstSnippetItr,
+                                            SnippetHitMap::iterator& startItr,
+                                            SnippetHitMap::iterator& endItr,
+                                            HitMatchTripletVecMap& hitMatchMap) const
+  {
     int numPairs(0);
 
-    HitVector::iterator firstMaxItr = std::max_element(firstSnippetItr->second.begin(),firstSnippetItr->second.end(),[](const auto& left, const auto& right){return left->getHit()->PeakAmplitude() < right->getHit()->PeakAmplitude();});
-    float               firstPHCut  = firstMaxItr != firstSnippetItr->second.end() ? m_pulseHeightFrac * (*firstMaxItr)->getHit()->PeakAmplitude() : 4096.;
+    HitVector::iterator firstMaxItr =
+      std::max_element(firstSnippetItr->second.begin(),
+                       firstSnippetItr->second.end(),
+                       [](const auto& left, const auto& right) {
+                         return left->getHit()->PeakAmplitude() < right->getHit()->PeakAmplitude();
+                       });
+    float firstPHCut = firstMaxItr != firstSnippetItr->second.end() ?
+                         m_pulseHeightFrac * (*firstMaxItr)->getHit()->PeakAmplitude() :
+                         4096.;
 
     // Loop through the hits on the first snippet
-    for(const auto& hit1 : firstSnippetItr->second)
-    {
-        // Let's focus on the largest hit in the chain
-        if (hit1->getHit()->DegreesOfFreedom() > 1 && hit1->getHit()->PeakAmplitude() < firstPHCut && hit1->getHit()->PeakAmplitude() < m_PHLowSelection) continue;
+    for (const auto& hit1 : firstSnippetItr->second) {
+      // Let's focus on the largest hit in the chain
+      if (hit1->getHit()->DegreesOfFreedom() > 1 && hit1->getHit()->PeakAmplitude() < firstPHCut &&
+          hit1->getHit()->PeakAmplitude() < m_PHLowSelection)
+        continue;
 
-        // Inside loop iterator
-        SnippetHitMap::iterator secondHitItr = startItr;
+      // Inside loop iterator
+      SnippetHitMap::iterator secondHitItr = startItr;
 
-        // Loop through the input secon hits and make pairs
-        while(secondHitItr != endItr)
-        {
-            HitVector::iterator secondMaxItr = std::max_element(secondHitItr->second.begin(),secondHitItr->second.end(),[](const auto& left, const auto& right){return left->getHit()->PeakAmplitude() < right->getHit()->PeakAmplitude();});
-            float               secondPHCut  = secondMaxItr != secondHitItr->second.end() ? m_pulseHeightFrac * (*secondMaxItr)->getHit()->PeakAmplitude() : 0.;
+      // Loop through the input secon hits and make pairs
+      while (secondHitItr != endItr) {
+        HitVector::iterator secondMaxItr = std::max_element(
+          secondHitItr->second.begin(),
+          secondHitItr->second.end(),
+          [](const auto& left, const auto& right) {
+            return left->getHit()->PeakAmplitude() < right->getHit()->PeakAmplitude();
+          });
+        float secondPHCut = secondMaxItr != secondHitItr->second.end() ?
+                              m_pulseHeightFrac * (*secondMaxItr)->getHit()->PeakAmplitude() :
+                              0.;
 
-            for(const auto& hit2 : secondHitItr->second)
-            {
-                // Again, focus on the large hits
-                if (hit2->getHit()->DegreesOfFreedom() > 1 && hit2->getHit()->PeakAmplitude() < secondPHCut && hit2->getHit()->PeakAmplitude() < m_PHLowSelection) continue;
+        for (const auto& hit2 : secondHitItr->second) {
+          // Again, focus on the large hits
+          if (hit2->getHit()->DegreesOfFreedom() > 1 &&
+              hit2->getHit()->PeakAmplitude() < secondPHCut &&
+              hit2->getHit()->PeakAmplitude() < m_PHLowSelection)
+            continue;
 
-                reco::ClusterHit3D  pair;
+          reco::ClusterHit3D pair;
 
-                // pair returned with a negative ave time is signal of failure
-                if (!makeHitPair(pair, hit1, hit2, m_hitWidthSclFctr)) continue;
+          // pair returned with a negative ave time is signal of failure
+          if (!makeHitPair(pair, hit1, hit2, m_hitWidthSclFctr)) continue;
 
-                std::vector<const recob::Hit*> recobHitVec = {nullptr,nullptr,nullptr};
+          std::vector<const recob::Hit*> recobHitVec = {nullptr, nullptr, nullptr};
 
-                recobHitVec[hit1->WireID().Plane] = hit1->getHit();
-                recobHitVec[hit2->WireID().Plane] = hit2->getHit();
+          recobHitVec[hit1->WireID().Plane] = hit1->getHit();
+          recobHitVec[hit2->WireID().Plane] = hit2->getHit();
 
-                geo::WireID wireID = hit2->WireID();
+          geo::WireID wireID = hit2->WireID();
 
-                hitMatchMap[wireID].emplace_back(hit1,hit2,pair);
+          hitMatchMap[wireID].emplace_back(hit1, hit2, pair);
 
-                numPairs++;
-            }
-
-            secondHitItr++;
+          numPairs++;
         }
+
+        secondHitItr++;
+      }
     }
 
     return numPairs;
-}
+  }
 
-void SnippetHit3DBuilder::findGoodTriplets(HitMatchTripletVecMap& pair12Map, 
-                                              HitMatchTripletVecMap& pair13Map, 
-                                              MatchedHitMap&         matchedHitMap,
-                                              reco::HitPairList&     hitPairList, 
-                                              bool                   tagged) const
-{
+  void SnippetHit3DBuilder::findGoodTriplets(HitMatchTripletVecMap& pair12Map,
+                                             HitMatchTripletVecMap& pair13Map,
+                                             MatchedHitMap& matchedHitMap,
+                                             reco::HitPairList& hitPairList,
+                                             bool tagged) const
+  {
     // Build triplets from the two lists of hit pairs
-    if (!pair12Map.empty() && !pair13Map.empty())
-    {
-        // temporary container for dead channel hits
-        std::vector<reco::ClusterHit3D> tempDeadChanVec;
-        reco::ClusterHit3D              deadChanPair;
+    if (!pair12Map.empty() && !pair13Map.empty()) {
+      // temporary container for dead channel hits
+      std::vector<reco::ClusterHit3D> tempDeadChanVec;
+      reco::ClusterHit3D deadChanPair;
 
-        // Keep track of which third plane hits have been used
-        std::map<const reco::ClusterHit3D*,bool> usedPairMap;
+      // Keep track of which third plane hits have been used
+      std::map<const reco::ClusterHit3D*, bool> usedPairMap;
 
-        // Initial population of this map with the pair13Map hits
-        for(const auto& pair13 : pair13Map)
-        {
-            for(const auto& hit2Dhit3DPair : pair13.second) usedPairMap[&std::get<2>(hit2Dhit3DPair)] = false;
-        }
+      // Initial population of this map with the pair13Map hits
+      for (const auto& pair13 : pair13Map) {
+        for (const auto& hit2Dhit3DPair : pair13.second)
+          usedPairMap[&std::get<2>(hit2Dhit3DPair)] = false;
+      }
 
-        // The outer loop is over all hit pairs made from the first two plane combinations
-        for(const auto& pair12 : pair12Map)
-        {
-            if (pair12.second.empty()) continue;
+      // The outer loop is over all hit pairs made from the first two plane combinations
+      for (const auto& pair12 : pair12Map) {
+        if (pair12.second.empty()) continue;
 
-            // This loop is over hit pairs that share the same first two plane wires but may have different
-            // hit times on those wires
-            for(const auto& hit2Dhit3DPair12 : pair12.second)
-            {
-                const reco::ClusterHit3D& pair1  = std::get<2>(hit2Dhit3DPair12);
+        // This loop is over hit pairs that share the same first two plane wires but may have different
+        // hit times on those wires
+        for (const auto& hit2Dhit3DPair12 : pair12.second) {
+          const reco::ClusterHit3D& pair1 = std::get<2>(hit2Dhit3DPair12);
 
-                // populate the map with initial value
-                usedPairMap[&pair1] = false;
+          // populate the map with initial value
+          usedPairMap[&pair1] = false;
 
-                // The simplest approach here is to loop over all possibilities and let the triplet builder weed out the weak candidates
-                for(const auto& pair13 : pair13Map)
-                {
-                    if (pair13.second.empty()) continue;
+          // The simplest approach here is to loop over all possibilities and let the triplet builder weed out the weak candidates
+          for (const auto& pair13 : pair13Map) {
+            if (pair13.second.empty()) continue;
 
-                    for(const auto& hit2Dhit3DPair13 : pair13.second)
-                    {
-                        // Protect against double counting
-                        if (std::get<0>(hit2Dhit3DPair12) != std::get<0>(hit2Dhit3DPair13)) continue;
+            for (const auto& hit2Dhit3DPair13 : pair13.second) {
+              // Protect against double counting
+              if (std::get<0>(hit2Dhit3DPair12) != std::get<0>(hit2Dhit3DPair13)) continue;
 
-                        const reco::ClusterHit2D* hit2  = std::get<1>(hit2Dhit3DPair13);
-                        const reco::ClusterHit3D& pair2 = std::get<2>(hit2Dhit3DPair13);
+              const reco::ClusterHit2D* hit2 = std::get<1>(hit2Dhit3DPair13);
+              const reco::ClusterHit3D& pair2 = std::get<2>(hit2Dhit3DPair13);
 
-                        // If success try for the triplet
-                        reco::ClusterHit3D triplet;
+              // If success try for the triplet
+              reco::ClusterHit3D triplet;
 
-                        if (makeHitTriplet(triplet, matchedHitMap, pair1, hit2))
-                        {
-                            triplet.setID(hitPairList.size());
-                            hitPairList.emplace_back(triplet);
-                            usedPairMap[&pair1] = true;
-                            usedPairMap[&pair2] = true;
-                        }
-                    }
-                }
+              if (makeHitTriplet(triplet, matchedHitMap, pair1, hit2)) {
+                triplet.setID(hitPairList.size());
+                hitPairList.emplace_back(triplet);
+                usedPairMap[&pair1] = true;
+                usedPairMap[&pair2] = true;
+              }
             }
+          }
         }
+      }
     }
 
     return;
-}
+  }
 
-int SnippetHit3DBuilder::saveOrphanPairs(HitMatchTripletVecMap& pairMap, MatchedHitMap& matchedHitMap, reco::HitPairList& hitPairList) const
-{
+  int SnippetHit3DBuilder::saveOrphanPairs(HitMatchTripletVecMap& pairMap,
+                                           MatchedHitMap& matchedHitMap,
+                                           reco::HitPairList& hitPairList) const
+  {
     int curTripletCount = hitPairList.size();
 
     // Build triplets from the two lists of hit pairs
-    if (!pairMap.empty())
-    {
-        // Initial population of this map with the pair13Map hits
-        for(const auto& pair : pairMap)
-        {
-            if (pair.second.empty()) continue;
+    if (!pairMap.empty()) {
+      // Initial population of this map with the pair13Map hits
+      for (const auto& pair : pairMap) {
+        if (pair.second.empty()) continue;
 
-            // This loop is over hit pairs that share the same first two plane wires but may have different
-            // hit times on those wires
-            for(const auto& hit2Dhit3DPair : pair.second)
-            {
-                const reco::ClusterHit3D& hit3D = std::get<2>(hit2Dhit3DPair);
+        // This loop is over hit pairs that share the same first two plane wires but may have different
+        // hit times on those wires
+        for (const auto& hit2Dhit3DPair : pair.second) {
+          const reco::ClusterHit3D& hit3D = std::get<2>(hit2Dhit3DPair);
 
-                // No point considering a 3D hit that has been used to make a space point already
-                if (hit3D.getStatusBits() & reco::ClusterHit3D::MADESPACEPOINT) continue;
+          // No point considering a 3D hit that has been used to make a space point already
+          if (hit3D.getStatusBits() & reco::ClusterHit3D::MADESPACEPOINT) continue;
 
-                const reco::ClusterHit2D* hit1 = std::get<0>(hit2Dhit3DPair);
-                const reco::ClusterHit2D* hit2 = std::get<1>(hit2Dhit3DPair);
+          const reco::ClusterHit2D* hit1 = std::get<0>(hit2Dhit3DPair);
+          const reco::ClusterHit2D* hit2 = std::get<1>(hit2Dhit3DPair);
 
-                // Have these already been used in some fashion?
-                if (matchedHitMap[hit1].find(hit2) != matchedHitMap[hit1].end()) continue;
+          // Have these already been used in some fashion?
+          if (matchedHitMap[hit1].find(hit2) != matchedHitMap[hit1].end()) continue;
 
-                if (m_outputHistograms)
-                {
-                    m_2hit1stPHVec.emplace_back(hit1->getHit()->PeakAmplitude());
-                    m_2hit2ndPHVec.emplace_back(hit2->getHit()->PeakAmplitude());
-                    m_2hitDeltaPHVec.emplace_back(hit2->getHit()->PeakAmplitude() - hit1->getHit()->PeakAmplitude());
-                    m_2hitSumPHVec.emplace_back(hit2->getHit()->PeakAmplitude() + hit1->getHit()->PeakAmplitude());
-                }
+          if (m_outputHistograms) {
+            m_2hit1stPHVec.emplace_back(hit1->getHit()->PeakAmplitude());
+            m_2hit2ndPHVec.emplace_back(hit2->getHit()->PeakAmplitude());
+            m_2hitDeltaPHVec.emplace_back(hit2->getHit()->PeakAmplitude() -
+                                          hit1->getHit()->PeakAmplitude());
+            m_2hitSumPHVec.emplace_back(hit2->getHit()->PeakAmplitude() +
+                                        hit1->getHit()->PeakAmplitude());
+          }
 
-                // If both hits already appear in a triplet then there is no gain here so reject
-                if (hit1->getHit()->PeakAmplitude() < m_minPHFor2HitPoints || hit2->getHit()->PeakAmplitude() < m_minPHFor2HitPoints) continue;
+          // If both hits already appear in a triplet then there is no gain here so reject
+          if (hit1->getHit()->PeakAmplitude() < m_minPHFor2HitPoints ||
+              hit2->getHit()->PeakAmplitude() < m_minPHFor2HitPoints)
+            continue;
 
-                // Require that one of the hits is on the collection plane
-                if (hit1->WireID().Plane == 2 || hit2->WireID().Plane == 2)
-                {
-                    // Allow cut on the quality of the space point
-                    if (hit3D.getHitChiSquare() < m_maxMythicalChiSquare)
-                    {
-                        // Add to the list
-                        hitPairList.emplace_back(hit3D);
-                        hitPairList.back().setID(hitPairList.size()-1);
-                        matchedHitMap[hit1].insert(hit2);
-                        matchedHitMap[hit2].insert(hit1);
-                    }
-                }
+          // Require that one of the hits is on the collection plane
+          if (hit1->WireID().Plane == 2 || hit2->WireID().Plane == 2) {
+            // Allow cut on the quality of the space point
+            if (hit3D.getHitChiSquare() < m_maxMythicalChiSquare) {
+              // Add to the list
+              hitPairList.emplace_back(hit3D);
+              hitPairList.back().setID(hitPairList.size() - 1);
+              matchedHitMap[hit1].insert(hit2);
+              matchedHitMap[hit2].insert(hit1);
             }
+          }
         }
+      }
     }
 
     return hitPairList.size() - curTripletCount;
-}
+  }
 
-int SnippetHit3DBuilder::saveBadChannelPairs(HitMatchTripletVecMap& pairMap, MatchedHitMap& matchedHitMap, reco::HitPairList& hitPairList) const
-{
+  int SnippetHit3DBuilder::saveBadChannelPairs(HitMatchTripletVecMap& pairMap,
+                                               MatchedHitMap& matchedHitMap,
+                                               reco::HitPairList& hitPairList) const
+  {
     int curTripletCount = hitPairList.size();
 
     // Assuming we havebad channels and the pairmap is not empty...
-    if (!m_channelFilter->NoisyChannels().empty() && !pairMap.empty())
-    {
-        // Initial population of this map with the pairMap hits
-        for(const auto& pair : pairMap)
-        {
-            if (pair.second.empty()) continue;
+    if (!m_channelFilter->NoisyChannels().empty() && !pairMap.empty()) {
+      // Initial population of this map with the pairMap hits
+      for (const auto& pair : pairMap) {
+        if (pair.second.empty()) continue;
 
-            // This loop is over hit pairs that share the same first two plane wires but may have different
-            // hit times on those wires
-            for(const auto& hit2Dhit3DPair : pair.second)
-            {
-                const reco::ClusterHit3D& hit3D = std::get<2>(hit2Dhit3DPair);
+        // This loop is over hit pairs that share the same first two plane wires but may have different
+        // hit times on those wires
+        for (const auto& hit2Dhit3DPair : pair.second) {
+          const reco::ClusterHit3D& hit3D = std::get<2>(hit2Dhit3DPair);
 
-                // No point considering a 3D hit that has been used to make a space point already
-                if (hit3D.getStatusBits() & reco::ClusterHit3D::MADESPACEPOINT) continue;
+          // No point considering a 3D hit that has been used to make a space point already
+          if (hit3D.getStatusBits() & reco::ClusterHit3D::MADESPACEPOINT) continue;
 
-                const reco::ClusterHit2D* hit0 = std::get<0>(hit2Dhit3DPair);
-                const reco::ClusterHit2D* hit1 = std::get<1>(hit2Dhit3DPair);
+          const reco::ClusterHit2D* hit0 = std::get<0>(hit2Dhit3DPair);
+          const reco::ClusterHit2D* hit1 = std::get<1>(hit2Dhit3DPair);
 
-                // Have both of these hits already been used in some fashion?
-                if (matchedHitMap.find(hit0) != matchedHitMap.end() && matchedHitMap[hit0].find(hit1) != matchedHitMap[hit0].end()) continue;
+          // Have both of these hits already been used in some fashion?
+          if (matchedHitMap.find(hit0) != matchedHitMap.end() &&
+              matchedHitMap[hit0].find(hit1) != matchedHitMap[hit0].end())
+            continue;
 
-                // Which plane is missing?
-                geo::WireID wireID0 = hit0->WireID();
-                geo::WireID wireID1 = hit1->WireID();
+          // Which plane is missing?
+          geo::WireID wireID0 = hit0->WireID();
+          geo::WireID wireID1 = hit1->WireID();
 
-                // Determine the missing plane
-                int missPlane = 3 - (wireID0.Plane + wireID1.Plane);
-        
-                // Ok, recover the wireID expected in the third plane...
-                geo::WireID wireIn(wireID0.Cryostat,wireID0.TPC,missPlane,0);
-                geo::WireID wireID = NearestWireID(hit3D.getPosition(), wireIn);
-        
-                raw::ChannelID_t channel = m_wireReadoutAlg->PlaneWireToChannel(wireID);
-        
-                geo::WireID wireIDNext(wireID.Cryostat,wireID.TPC,wireID.Plane,wireID.Wire+1);
-                raw::ChannelID_t chanNext = m_wireReadoutAlg->PlaneWireToChannel(wireIDNext);
-        
-                bool wireStatus    =  m_channelFilter->IsPresent(channel)  && !m_channelFilter->IsGood(channel);
-                bool wireOneStatus =  m_channelFilter->IsPresent(chanNext) && !m_channelFilter->IsGood(chanNext);
+          // Determine the missing plane
+          int missPlane = 3 - (wireID0.Plane + wireID1.Plane);
 
-                // Make sure they are of at least the minimum status
-                if(wireStatus || wireOneStatus)
-                {
-                    // Sort out which is the wire we're dealing with
-                    if (!wireStatus) wireID = wireIDNext;
+          // Ok, recover the wireID expected in the third plane...
+          geo::WireID wireIn(wireID0.Cryostat, wireID0.TPC, missPlane, 0);
+          geo::WireID wireID = NearestWireID(hit3D.getPosition(), wireIn);
 
-                    // Want to refine position since we "know" the missing wire
-                    if (auto widIntersect0 = m_wireReadoutAlg->WireIDsIntersect(wireID0, wireID))
-                    {
-                        if (auto widIntersect1 = m_wireReadoutAlg->WireIDsIntersect(wireID1, wireID))
-                        {
-                            Eigen::Vector3f newPosition(hit3D.getPosition()[0],hit3D.getPosition()[1],hit3D.getPosition()[2]);
+          raw::ChannelID_t channel = m_wireReadoutAlg->PlaneWireToChannel(wireID);
 
-                            newPosition[1] = (newPosition[1] + widIntersect0->y + widIntersect1->y) / 3.;
-                            newPosition[2] = (newPosition[2] + widIntersect0->z + widIntersect1->z - 2. * m_zPosOffset) / 3.;
+          geo::WireID wireIDNext(wireID.Cryostat, wireID.TPC, wireID.Plane, wireID.Wire + 1);
+          raw::ChannelID_t chanNext = m_wireReadoutAlg->PlaneWireToChannel(wireIDNext);
 
-                            hit3D.setPosition(newPosition);
-        
-                            if (hit0->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET) hit0->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
-                            if (hit1->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET) hit1->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
-        
-                            hit0->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
-                            hit1->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
-        
-                            // Add to the list
-                            hitPairList.emplace_back(hit3D);
-                            hitPairList.back().setID(hitPairList.size()-1);
-                            matchedHitMap[hit0].insert(hit1);
-                            matchedHitMap[hit1].insert(hit0);
-                        }
-                    }
-                }
+          bool wireStatus =
+            m_channelFilter->IsPresent(channel) && !m_channelFilter->IsGood(channel);
+          bool wireOneStatus =
+            m_channelFilter->IsPresent(chanNext) && !m_channelFilter->IsGood(chanNext);
+
+          // Make sure they are of at least the minimum status
+          if (wireStatus || wireOneStatus) {
+            // Sort out which is the wire we're dealing with
+            if (!wireStatus) wireID = wireIDNext;
+
+            // Want to refine position since we "know" the missing wire
+            if (auto widIntersect0 = m_wireReadoutAlg->WireIDsIntersect(wireID0, wireID)) {
+              if (auto widIntersect1 = m_wireReadoutAlg->WireIDsIntersect(wireID1, wireID)) {
+                Eigen::Vector3f newPosition(
+                  hit3D.getPosition()[0], hit3D.getPosition()[1], hit3D.getPosition()[2]);
+
+                newPosition[1] = (newPosition[1] + widIntersect0->y + widIntersect1->y) / 3.;
+                newPosition[2] =
+                  (newPosition[2] + widIntersect0->z + widIntersect1->z - 2. * m_zPosOffset) / 3.;
+
+                hit3D.setPosition(newPosition);
+
+                if (hit0->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET)
+                  hit0->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
+                if (hit1->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET)
+                  hit1->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
+
+                hit0->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
+                hit1->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
+
+                // Add to the list
+                hitPairList.emplace_back(hit3D);
+                hitPairList.back().setID(hitPairList.size() - 1);
+                matchedHitMap[hit0].insert(hit1);
+                matchedHitMap[hit1].insert(hit0);
+              }
             }
+          }
         }
+      }
     }
 
     return hitPairList.size() - curTripletCount;
-}
+  }
 
-bool SnippetHit3DBuilder::makeHitPair(reco::ClusterHit3D&       hitPair,
-                                         const reco::ClusterHit2D* hit1,
-                                         const reco::ClusterHit2D* hit2,
-                                         float                     hitWidthSclFctr,
-                                         size_t                    hitPairCntr) const
-{
+  bool SnippetHit3DBuilder::makeHitPair(reco::ClusterHit3D& hitPair,
+                                        const reco::ClusterHit2D* hit1,
+                                        const reco::ClusterHit2D* hit2,
+                                        float hitWidthSclFctr,
+                                        size_t hitPairCntr) const
+  {
     // Assume failure
     bool result(false);
 
     // Start by checking time consistency since this is fastest
     // Wires intersect so now we can check the timing
-    float hit1Peak  = hit1->getTimeTicks();
+    float hit1Peak = hit1->getTimeTicks();
     float hit1Sigma = hit1->getHit()->RMS();
 
-    float hit2Peak  = hit2->getTimeTicks();
+    float hit2Peak = hit2->getTimeTicks();
     float hit2Sigma = hit2->getHit()->RMS();
 
     // "Long hits" are an issue... so we deal with these differently
-    int   hit1NDF   = hit1->getHit()->DegreesOfFreedom();
-    int   hit2NDF   = hit2->getHit()->DegreesOfFreedom();
+    int hit1NDF = hit1->getHit()->DegreesOfFreedom();
+    int hit2NDF = hit2->getHit()->DegreesOfFreedom();
 
     // Basically, allow the range to extend to the nearest end of the snippet
-    if (hit1NDF < 2) hit1Sigma *= m_LongHitStretchFctr; // This sets the range to the width of the pulse
+    if (hit1NDF < 2)
+      hit1Sigma *= m_LongHitStretchFctr; // This sets the range to the width of the pulse
     if (hit2NDF < 2) hit2Sigma *= m_LongHitStretchFctr;
 
     // The "hit sigma" is the gaussian fit sigma of the hit, we need to expand a bit to allow hit overlap efficiency
@@ -1058,425 +1120,439 @@ bool SnippetHit3DBuilder::makeHitPair(reco::ClusterHit3D&       hitPair,
     float hit2Width = hitWidthSclFctr * hit2Sigma;
 
     // Coarse check hit times are "in range"
-    if (fabs(hit1Peak - hit2Peak) <= (hit1Width + hit2Width))
-    {
-        // Check to see that hit peak times are consistent with each other
-        float hit1SigSq     = std::pow(hit1Sigma,2);
-        float hit2SigSq     = std::pow(hit2Sigma,2);
-        float deltaPeakTime = std::fabs(hit1Peak - hit2Peak);
-        float sigmaPeakTime = std::sqrt(hit1SigSq + hit2SigSq);
+    if (fabs(hit1Peak - hit2Peak) <= (hit1Width + hit2Width)) {
+      // Check to see that hit peak times are consistent with each other
+      float hit1SigSq = std::pow(hit1Sigma, 2);
+      float hit2SigSq = std::pow(hit2Sigma, 2);
+      float deltaPeakTime = std::fabs(hit1Peak - hit2Peak);
+      float sigmaPeakTime = std::sqrt(hit1SigSq + hit2SigSq);
 
-        if (m_outputHistograms)
-        {
-            // brute force... sigh... 
-            int plane1   = hit1->WireID().Plane;
-            int plane2   = hit2->WireID().Plane;
-            int planeIdx = (plane1 + plane2) - 1;     // should be 0 for 0-1, 1 for 0-2 and 2 for 1-2
+      if (m_outputHistograms) {
+        // brute force... sigh...
+        int plane1 = hit1->WireID().Plane;
+        int plane2 = hit2->WireID().Plane;
+        int planeIdx = (plane1 + plane2) - 1; // should be 0 for 0-1, 1 for 0-2 and 2 for 1-2
 
-            float deltaTicks = hit2Peak - hit1Peak;
+        float deltaTicks = hit2Peak - hit1Peak;
 
-            if (plane1 > plane2) deltaTicks = -deltaTicks;
+        if (plane1 > plane2) deltaTicks = -deltaTicks;
 
-            if (planeIdx == 0)
-            {
-                m_deltaPeakTimePlane0Vec.emplace_back(deltaTicks);
-                m_deltaPeakSigmaPlane0Vec.emplace_back(sigmaPeakTime);
-            }
-            else if (planeIdx == 1)
-            {
-                m_deltaPeakTimePlane1Vec.emplace_back(deltaTicks);
-                m_deltaPeakSigmaPlane1Vec.emplace_back(sigmaPeakTime);
-            }
-            else
-            {
-                m_deltaPeakTimePlane2Vec.emplace_back(deltaTicks);
-                m_deltaPeakSigmaPlane2Vec.emplace_back(sigmaPeakTime);
-            }
+        if (planeIdx == 0) {
+          m_deltaPeakTimePlane0Vec.emplace_back(deltaTicks);
+          m_deltaPeakSigmaPlane0Vec.emplace_back(sigmaPeakTime);
         }
-
-        // delta peak time consistency check here
-        if (deltaPeakTime < m_deltaPeakTimeSig * sigmaPeakTime)    // 2 sigma consistency? (do this way to avoid divide)
-        {
-            // We assume in this routine that we are looking at hits in different views
-            // The first mission is to check that the wires intersect
-            const geo::WireID& hit1WireID = hit1->WireID();
-            const geo::WireID& hit2WireID = hit2->WireID();
-
-            geo::WireIDIntersection widIntersect;
-
-            if (WireIDsIntersect(hit1WireID, hit2WireID, widIntersect))
-            {
-                float oneOverWghts  = hit1SigSq * hit2SigSq / (hit1SigSq + hit2SigSq);
-                float avePeakTime   = (hit1Peak / hit1SigSq + hit2Peak / hit2SigSq) * oneOverWghts;
-                float averageCharge = 0.5 * (hit1->getHit()->Integral() + hit2->getHit()->Integral());
-                float hitChiSquare  = std::pow((hit1Peak - avePeakTime),2) / hit1SigSq
-                                    + std::pow((hit2Peak - avePeakTime),2) / hit2SigSq;
-
-                float xPositionHit1(hit1->getXPosition());
-                float xPositionHit2(hit2->getXPosition());
-                float xPosition = (xPositionHit1 / hit1SigSq + xPositionHit2 / hit2SigSq) * hit1SigSq * hit2SigSq / (hit1SigSq + hit2SigSq);
-
-                Eigen::Vector3f position(xPosition, float(widIntersect.y), float(widIntersect.z)-m_zPosOffset);
-
-                // If to here then we need to sort out the hit pair code telling what views are used
-                unsigned statusBits = 1 << hit1->WireID().Plane | 1 << hit2->WireID().Plane;
-
-                // handle status bits for the 2D hits
-                if (hit1->getStatusBits() & reco::ClusterHit2D::USEDINPAIR) hit1->setStatusBit(reco::ClusterHit2D::SHAREDINPAIR);
-                if (hit2->getStatusBits() & reco::ClusterHit2D::USEDINPAIR) hit2->setStatusBit(reco::ClusterHit2D::SHAREDINPAIR);
-
-                hit1->setStatusBit(reco::ClusterHit2D::USEDINPAIR);
-                hit2->setStatusBit(reco::ClusterHit2D::USEDINPAIR);
-
-                reco::ClusterHit2DVec hitVector;
-
-                hitVector.resize(3, NULL);
-
-                hitVector[hit1->WireID().Plane] = hit1;
-                hitVector[hit2->WireID().Plane] = hit2;
-
-                unsigned int cryostatIdx = hit1->WireID().Cryostat;
-                unsigned int tpcIdx      = hit1->WireID().TPC;
-
-                // Initialize the wireIdVec
-                std::vector<geo::WireID> wireIDVec = {geo::WireID(cryostatIdx,tpcIdx,0,0),
-                                                      geo::WireID(cryostatIdx,tpcIdx,1,0),
-                                                      geo::WireID(cryostatIdx,tpcIdx,2,0)};
-
-                wireIDVec[hit1->WireID().Plane] = hit1->WireID();
-                wireIDVec[hit2->WireID().Plane] = hit2->WireID();
-
-                // For compiling at the moment
-                std::vector<float> hitDelTSigVec = {0.,0.,0.};
-
-                hitDelTSigVec[hit1->WireID().Plane] = deltaPeakTime / sigmaPeakTime;
-                hitDelTSigVec[hit2->WireID().Plane] = deltaPeakTime / sigmaPeakTime;
-
-                // Create the 3D cluster hit
-                hitPair.initialize(hitPairCntr,
-                                   statusBits,
-                                   position,
-                                   averageCharge,
-                                   avePeakTime,
-                                   deltaPeakTime,
-                                   sigmaPeakTime,
-                                   hitChiSquare,
-                                   0.,
-                                   0.,
-                                   0.,
-                                   0.,
-                                   hitVector,
-                                   hitDelTSigVec,
-                                   wireIDVec);
-
-                result = true;
-            }
+        else if (planeIdx == 1) {
+          m_deltaPeakTimePlane1Vec.emplace_back(deltaTicks);
+          m_deltaPeakSigmaPlane1Vec.emplace_back(sigmaPeakTime);
         }
+        else {
+          m_deltaPeakTimePlane2Vec.emplace_back(deltaTicks);
+          m_deltaPeakSigmaPlane2Vec.emplace_back(sigmaPeakTime);
+        }
+      }
+
+      // delta peak time consistency check here
+      if (deltaPeakTime <
+          m_deltaPeakTimeSig * sigmaPeakTime) // 2 sigma consistency? (do this way to avoid divide)
+      {
+        // We assume in this routine that we are looking at hits in different views
+        // The first mission is to check that the wires intersect
+        const geo::WireID& hit1WireID = hit1->WireID();
+        const geo::WireID& hit2WireID = hit2->WireID();
+
+        geo::WireIDIntersection widIntersect;
+
+        if (WireIDsIntersect(hit1WireID, hit2WireID, widIntersect)) {
+          float oneOverWghts = hit1SigSq * hit2SigSq / (hit1SigSq + hit2SigSq);
+          float avePeakTime = (hit1Peak / hit1SigSq + hit2Peak / hit2SigSq) * oneOverWghts;
+          float averageCharge = 0.5 * (hit1->getHit()->Integral() + hit2->getHit()->Integral());
+          float hitChiSquare = std::pow((hit1Peak - avePeakTime), 2) / hit1SigSq +
+                               std::pow((hit2Peak - avePeakTime), 2) / hit2SigSq;
+
+          float xPositionHit1(hit1->getXPosition());
+          float xPositionHit2(hit2->getXPosition());
+          float xPosition = (xPositionHit1 / hit1SigSq + xPositionHit2 / hit2SigSq) * hit1SigSq *
+                            hit2SigSq / (hit1SigSq + hit2SigSq);
+
+          Eigen::Vector3f position(
+            xPosition, float(widIntersect.y), float(widIntersect.z) - m_zPosOffset);
+
+          // If to here then we need to sort out the hit pair code telling what views are used
+          unsigned statusBits = 1 << hit1->WireID().Plane | 1 << hit2->WireID().Plane;
+
+          // handle status bits for the 2D hits
+          if (hit1->getStatusBits() & reco::ClusterHit2D::USEDINPAIR)
+            hit1->setStatusBit(reco::ClusterHit2D::SHAREDINPAIR);
+          if (hit2->getStatusBits() & reco::ClusterHit2D::USEDINPAIR)
+            hit2->setStatusBit(reco::ClusterHit2D::SHAREDINPAIR);
+
+          hit1->setStatusBit(reco::ClusterHit2D::USEDINPAIR);
+          hit2->setStatusBit(reco::ClusterHit2D::USEDINPAIR);
+
+          reco::ClusterHit2DVec hitVector;
+
+          hitVector.resize(3, NULL);
+
+          hitVector[hit1->WireID().Plane] = hit1;
+          hitVector[hit2->WireID().Plane] = hit2;
+
+          unsigned int cryostatIdx = hit1->WireID().Cryostat;
+          unsigned int tpcIdx = hit1->WireID().TPC;
+
+          // Initialize the wireIdVec
+          std::vector<geo::WireID> wireIDVec = {geo::WireID(cryostatIdx, tpcIdx, 0, 0),
+                                                geo::WireID(cryostatIdx, tpcIdx, 1, 0),
+                                                geo::WireID(cryostatIdx, tpcIdx, 2, 0)};
+
+          wireIDVec[hit1->WireID().Plane] = hit1->WireID();
+          wireIDVec[hit2->WireID().Plane] = hit2->WireID();
+
+          // For compiling at the moment
+          std::vector<float> hitDelTSigVec = {0., 0., 0.};
+
+          hitDelTSigVec[hit1->WireID().Plane] = deltaPeakTime / sigmaPeakTime;
+          hitDelTSigVec[hit2->WireID().Plane] = deltaPeakTime / sigmaPeakTime;
+
+          // Create the 3D cluster hit
+          hitPair.initialize(hitPairCntr,
+                             statusBits,
+                             position,
+                             averageCharge,
+                             avePeakTime,
+                             deltaPeakTime,
+                             sigmaPeakTime,
+                             hitChiSquare,
+                             0.,
+                             0.,
+                             0.,
+                             0.,
+                             hitVector,
+                             hitDelTSigVec,
+                             wireIDVec);
+
+          result = true;
+        }
+      }
     }
 
     // Send it back
     return result;
-}
+  }
 
-
-bool SnippetHit3DBuilder::makeHitTriplet(reco::ClusterHit3D&       hitTriplet,
-                                            MatchedHitMap&            matchedHitMap,
-                                            const reco::ClusterHit3D& pair,
-                                            const reco::ClusterHit2D* hit) const
-{
+  bool SnippetHit3DBuilder::makeHitTriplet(reco::ClusterHit3D& hitTriplet,
+                                           MatchedHitMap& matchedHitMap,
+                                           const reco::ClusterHit3D& pair,
+                                           const reco::ClusterHit2D* hit) const
+  {
     // Assume failure
     bool result(false);
 
     // We are going to force the wire pitch here, some time in the future we need to fix
-    static const double wirePitch = 0.5 * m_wirePitchScaleFactor * *std::max_element(m_wirePitch,m_wirePitch+3);
+    static const double wirePitch =
+      0.5 * m_wirePitchScaleFactor * *std::max_element(m_wirePitch, m_wirePitch + 3);
 
     // Recover hit info
     float hitTimeTicks = hit->getTimeTicks();
-    float hitSigma     = hit->getHit()->RMS();
+    float hitSigma = hit->getHit()->RMS();
 
     // Special case check
-    if (hitSigma > 2. * hit->getHit()->PeakAmplitude()) hitSigma = 2. * hit->getHit()->PeakAmplitude();
+    if (hitSigma > 2. * hit->getHit()->PeakAmplitude())
+      hitSigma = 2. * hit->getHit()->PeakAmplitude();
 
     // Let's do a quick consistency check on the input hits to make sure we are in range...
     // Require the W hit to be "in range" with the UV Pair
-    if (fabs(hitTimeTicks - pair.getAvePeakTime()) < m_hitWidthSclFctr * (pair.getSigmaPeakTime() + hitSigma))
-    {
-        // Check the distance from the point to the wire the hit is on
-        float hitWireDist = DistanceFromPointToHitWire(pair.getPosition(), hit->WireID());
+    if (fabs(hitTimeTicks - pair.getAvePeakTime()) <
+        m_hitWidthSclFctr * (pair.getSigmaPeakTime() + hitSigma)) {
+      // Check the distance from the point to the wire the hit is on
+      float hitWireDist = DistanceFromPointToHitWire(pair.getPosition(), hit->WireID());
 
-        if (m_outputHistograms) m_maxSideVecVec.push_back(hitWireDist);
+      if (m_outputHistograms) m_maxSideVecVec.push_back(hitWireDist);
 
-        // Reject hits that are not within range
-        if (hitWireDist < wirePitch)
-        {
-            if (m_outputHistograms) m_pairWireDistVec.push_back(hitWireDist);
+      // Reject hits that are not within range
+      if (hitWireDist < wirePitch) {
+        if (m_outputHistograms) m_pairWireDistVec.push_back(hitWireDist);
 
-            // Let's mark that this pair had a valid 3 wire combination
+        // Let's mark that this pair had a valid 3 wire combination
+        pair.setStatusBit(reco::ClusterHit3D::MADESPACEPOINT);
+
+        // Use the existing code to see the U and W hits are willing to pair with the V hit
+        reco::ClusterHit3D pair0h;
+        reco::ClusterHit3D pair1h;
+
+        // Recover all the hits involved
+        const reco::ClusterHit2DVec& pairHitVec = pair.getHits();
+        const reco::ClusterHit2D* hit0 = pairHitVec[0];
+        const reco::ClusterHit2D* hit1 = pairHitVec[1];
+
+        if (!hit0)
+          hit0 = pairHitVec[2];
+        else if (!hit1)
+          hit1 = pairHitVec[2];
+
+        bool notMatched = matchedHitMap[hit].find(hit0) == matchedHitMap[hit].end() &&
+                          matchedHitMap[hit].find(hit1) == matchedHitMap[hit].end() &&
+                          matchedHitMap[hit0].find(hit1) == matchedHitMap[hit0].end();
+
+        // If good pairs made here then we can try to make a triplet
+        if (notMatched && makeHitPair(pair0h, hit0, hit, m_hitWidthSclFctr) &&
+            makeHitPair(pair1h, hit1, hit, m_hitWidthSclFctr)) {
+          // Get a copy of the input hit vector (note the order is by plane - by definition)
+          reco::ClusterHit2DVec hitVector = pair.getHits();
+
+          // include the new hit
+          hitVector[hit->WireID().Plane] = hit;
+
+          // Set up to get average peak time, hitChiSquare, etc.
+          unsigned int statusBits(0x7);
+          float avePeakTime(0.);
+          float weightSum(0.);
+          float xPosition(0.);
+
+          // And get the wire IDs
+          std::vector<geo::WireID> wireIDVec = {geo::WireID(), geo::WireID(), geo::WireID()};
+
+          // First loop through the hits to get WireIDs and calculate the averages
+          for (size_t planeIdx = 0; planeIdx < 3; planeIdx++) {
+            const reco::ClusterHit2D* hit2D = hitVector[planeIdx];
+
+            wireIDVec[planeIdx] = hit2D->WireID();
+
+            float hitRMS = hit2D->getHit()->RMS();
+            float peakTime = hit2D->getTimeTicks();
+
+            // Basically, allow the range to extend to the nearest end of the snippet
+            if (hit2D->getHit()->DegreesOfFreedom() < 2) hitRMS *= m_LongHitStretchFctr;
+            //hitRMS = std::min(hit2D->getTimeTicks() - float(hit2D->getHit()->StartTick()),float(hit2D->getHit()->EndTick())-hit2D->getTimeTicks());
+
+            float weight = 1. / (hitRMS * hitRMS);
+
+            avePeakTime += peakTime * weight;
+            xPosition += hit2D->getXPosition() * weight;
+            weightSum += weight;
+          }
+
+          avePeakTime /= weightSum;
+          xPosition /= weightSum;
+
+          Eigen::Vector2f pair0hYZVec(pair0h.getPosition()[1], pair0h.getPosition()[2]);
+          Eigen::Vector2f pair1hYZVec(pair1h.getPosition()[1], pair1h.getPosition()[2]);
+          Eigen::Vector2f pairYZVec(pair.getPosition()[1], pair.getPosition()[2]);
+          Eigen::Vector3f position(xPosition,
+                                   float((pairYZVec[0] + pair0hYZVec[0] + pair1hYZVec[0]) / 3.),
+                                   float((pairYZVec[1] + pair0hYZVec[1] + pair1hYZVec[1]) / 3.));
+
+          // Armed with the average peak time, now get hitChiSquare and the sig vec
+          float hitChiSquare(0.);
+          float sigmaPeakTime(std::sqrt(1. / weightSum));
+          std::vector<float> hitDelTSigVec;
+
+          for (const auto& hit2D : hitVector) {
+            float hitRMS = hit2D->getHit()->RMS();
+
+            // Basically, allow the range to extend to the nearest end of the snippet
+            if (hit2D->getHit()->DegreesOfFreedom() < 2) hitRMS *= m_LongHitStretchFctr;
+            //hitRMS = std::min(hit2D->getTimeTicks() - float(hit2D->getHit()->StartTick()),float(hit2D->getHit()->EndTick())-hit2D->getTimeTicks());
+
+            float combRMS = std::sqrt(hitRMS * hitRMS - sigmaPeakTime * sigmaPeakTime);
+            float peakTime = hit2D->getTimeTicks();
+            float deltaTime = peakTime - avePeakTime;
+            float hitSig = deltaTime / combRMS;
+
+            hitChiSquare += hitSig * hitSig;
+
+            hitDelTSigVec.emplace_back(std::fabs(hitSig));
+          }
+
+          if (m_outputHistograms) m_chiSquare3DVec.push_back(hitChiSquare);
+
+          int lowMinIndex(std::numeric_limits<int>::max());
+          int lowMaxIndex(std::numeric_limits<int>::min());
+          int hiMinIndex(std::numeric_limits<int>::max());
+          int hiMaxIndex(std::numeric_limits<int>::min());
+
+          // First task is to get the min/max values for the common overlap region
+          for (const auto& hit2D : hitVector) {
+            float range = m_rangeNumSig * hit2D->getHit()->RMS();
+
+            // Basically, allow the range to extend to the nearest end of the snippet
+            if (hit2D->getHit()->DegreesOfFreedom() < 2) range *= m_LongHitStretchFctr;
+            //range = std::min(hit2D->getTimeTicks() - float(hit2D->getHit()->StartTick()),float(hit2D->getHit()->EndTick())-hit2D->getTimeTicks());
+
+            int hitStart = hit2D->getHit()->PeakTime() - range - 0.5;
+            int hitStop = hit2D->getHit()->PeakTime() + range + 0.5;
+
+            lowMinIndex = std::min(hitStart, lowMinIndex);
+            lowMaxIndex = std::max(hitStart, lowMaxIndex);
+            hiMinIndex = std::min(hitStop + 1, hiMinIndex);
+            hiMaxIndex = std::max(hitStop + 1, hiMaxIndex);
+          }
+
+          // Keep only "good" hits...
+          if (hitChiSquare < m_maxHit3DChiSquare && hiMinIndex > lowMaxIndex) {
+            // One more pass through hits to get charge
+            std::vector<float> chargeVec;
+
+            for (const auto& hit2D : hitVector)
+              chargeVec.push_back(chargeIntegral(hit2D->getHit()->PeakTime(),
+                                                 hit2D->getHit()->PeakAmplitude(),
+                                                 hit2D->getHit()->RMS(),
+                                                 1.,
+                                                 lowMaxIndex,
+                                                 hiMinIndex));
+
+            float totalCharge =
+              std::accumulate(chargeVec.begin(), chargeVec.end(), 0.) / float(chargeVec.size());
+            float overlapRange = float(hiMinIndex - lowMaxIndex);
+            float overlapFraction = overlapRange / float(hiMaxIndex - lowMinIndex);
+
+            // Set up to compute the charge asymmetry
+            std::vector<float> smallestChargeDiffVec;
+            std::vector<float> chargeAveVec;
+            float smallestDiff(std::numeric_limits<float>::max());
+            float maxDeltaPeak(0.);
+            size_t chargeIndex(0);
+
+            for (size_t idx = 0; idx < 3; idx++) {
+              size_t leftIdx = (idx + 2) % 3;
+              size_t rightIdx = (idx + 1) % 3;
+
+              smallestChargeDiffVec.push_back(std::abs(chargeVec[leftIdx] - chargeVec[rightIdx]));
+              chargeAveVec.push_back(float(0.5 * (chargeVec[leftIdx] + chargeVec[rightIdx])));
+
+              if (smallestChargeDiffVec.back() < smallestDiff) {
+                smallestDiff = smallestChargeDiffVec.back();
+                chargeIndex = idx;
+              }
+
+              // Take opportunity to look at peak time diff
+              float deltaPeakTime =
+                hitVector[rightIdx]->getTimeTicks() - hitVector[leftIdx]->getTimeTicks();
+
+              if (std::abs(deltaPeakTime) > maxDeltaPeak) maxDeltaPeak = std::abs(deltaPeakTime);
+
+              if (m_outputHistograms) {
+                int deltaTimeIdx =
+                  (hitVector[leftIdx]->WireID().Plane + hitVector[rightIdx]->WireID().Plane) - 1;
+                float combRMS = std::sqrt(std::pow(hitVector[leftIdx]->getHit()->RMS(), 2) +
+                                          std::pow(hitVector[rightIdx]->getHit()->RMS(), 2));
+
+                m_deltaTimeVec.push_back(deltaPeakTime);
+
+                // Want to get the sign of the difference correct...
+                if (deltaTimeIdx == 0) // This is planes 1 and 0
+                {
+                  m_deltaTime0Vec.emplace_back(
+                    float(hitVector[1]->getTimeTicks() - hitVector[0]->getTimeTicks()));
+                  m_deltaSigma0Vec.emplace_back(combRMS);
+                }
+                else if (deltaTimeIdx == 1) // This is planes 0 and 2
+                {
+                  m_deltaTime1Vec.emplace_back(
+                    float(hitVector[2]->getTimeTicks() - hitVector[0]->getTimeTicks()));
+                  m_deltaSigma1Vec.emplace_back(combRMS);
+                }
+                else // must be planes 1 and 2
+                {
+                  m_deltaTime2Vec.emplace_back(
+                    float(hitVector[2]->getTimeTicks() - hitVector[1]->getTimeTicks()));
+                  m_deltaSigma2Vec.emplace_back(combRMS);
+                }
+              }
+            }
+
+            float chargeAsymmetry = (chargeAveVec[chargeIndex] - chargeVec[chargeIndex]) /
+                                    (chargeAveVec[chargeIndex] + chargeVec[chargeIndex]);
+
+            // If this is true there has to be a negative charge that snuck in somehow
+            if (chargeAsymmetry < -1. || chargeAsymmetry > 1.) {
+              const geo::WireID& hitWireID = hitVector[chargeIndex]->WireID();
+
+              std::cout << "============> Charge asymmetry out of range: " << chargeAsymmetry
+                        << " <============" << std::endl;
+              std::cout << "     hit C: " << hitWireID.Cryostat << ", TPC: " << hitWireID.TPC
+                        << ", Plane: " << hitWireID.Plane << ", Wire: " << hitWireID.Wire
+                        << std::endl;
+              std::cout << "     charge: " << chargeVec[0] << ", " << chargeVec[1] << ", "
+                        << chargeVec[2] << std::endl;
+              std::cout << "     index: " << chargeIndex << ", smallest diff: " << smallestDiff
+                        << std::endl;
+              return result;
+            }
+
+            // Usurping "deltaPeakTime" to be the maximum pull
+            float deltaPeakTime = *std::max_element(hitDelTSigVec.begin(), hitDelTSigVec.end());
+
+            if (m_outputHistograms) {
+              m_smallChargeDiffVec.push_back(smallestDiff);
+              m_smallIndexVec.push_back(chargeIndex);
+              m_maxPullVec.push_back(deltaPeakTime);
+              m_qualityMetricVec.push_back(hitChiSquare);
+              m_spacePointChargeVec.push_back(totalCharge);
+              m_overlapFractionVec.push_back(overlapFraction);
+              m_overlapRangeVec.push_back(overlapRange);
+              m_maxDeltaPeakVec.push_back(maxDeltaPeak);
+              m_hitAsymmetryVec.push_back(chargeAsymmetry);
+            }
+
+            // Try to weed out cases where overlap doesn't match peak separation
+            if (maxDeltaPeak > 3. * overlapRange) return result;
+
+            // Create the 3D cluster hit
+            hitTriplet.initialize(0,
+                                  statusBits,
+                                  position,
+                                  totalCharge,
+                                  avePeakTime,
+                                  deltaPeakTime,
+                                  sigmaPeakTime,
+                                  hitChiSquare,
+                                  overlapFraction,
+                                  chargeAsymmetry,
+                                  0.,
+                                  0.,
+                                  hitVector,
+                                  hitDelTSigVec,
+                                  wireIDVec);
+
+            // Since we are keeping the triplet, mark the hits as used
+            for (size_t hit2DIdx = 0; hit2DIdx < hitVector.size(); hit2DIdx++) {
+              const reco::ClusterHit2D* hit2D = hitVector[hit2DIdx];
+
+              matchedHitMap[hit2D].insert(hitVector[(hit2DIdx + 1) % hitVector.size()]);
+              matchedHitMap[hit2D].insert(hitVector[(hit2DIdx + 2) % hitVector.size()]);
+
+              if (hit2D->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET)
+                hit2D->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
+
+              hit2D->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
+            }
+
+            // Mark the input pair
             pair.setStatusBit(reco::ClusterHit3D::MADESPACEPOINT);
 
-            // Use the existing code to see the U and W hits are willing to pair with the V hit
-            reco::ClusterHit3D pair0h;
-            reco::ClusterHit3D pair1h;
-
-            // Recover all the hits involved
-            const reco::ClusterHit2DVec& pairHitVec = pair.getHits();
-            const reco::ClusterHit2D*    hit0       = pairHitVec[0];
-            const reco::ClusterHit2D*    hit1       = pairHitVec[1];
-
-            if      (!hit0) hit0 = pairHitVec[2];
-            else if (!hit1) hit1 = pairHitVec[2];
-
-            bool notMatched =  matchedHitMap[hit].find(hit0)  == matchedHitMap[hit].end() 
-                            && matchedHitMap[hit].find(hit1)  == matchedHitMap[hit].end()
-                            && matchedHitMap[hit0].find(hit1) == matchedHitMap[hit0].end();
-
-            // If good pairs made here then we can try to make a triplet
-            if (notMatched && makeHitPair(pair0h, hit0, hit, m_hitWidthSclFctr) && makeHitPair(pair1h, hit1, hit, m_hitWidthSclFctr))
-            {
-                // Get a copy of the input hit vector (note the order is by plane - by definition)
-                reco::ClusterHit2DVec hitVector = pair.getHits();
-
-                // include the new hit
-                hitVector[hit->WireID().Plane] = hit;
-
-                // Set up to get average peak time, hitChiSquare, etc.
-                unsigned int statusBits(0x7);
-                float        avePeakTime(0.);
-                float        weightSum(0.);
-                float        xPosition(0.);
-
-                // And get the wire IDs
-                std::vector<geo::WireID> wireIDVec = {geo::WireID(), geo::WireID(), geo::WireID()};
-
-                // First loop through the hits to get WireIDs and calculate the averages
-                for(size_t planeIdx = 0; planeIdx < 3; planeIdx++)
-                {
-                    const reco::ClusterHit2D* hit2D = hitVector[planeIdx];
-
-                    wireIDVec[planeIdx] = hit2D->WireID();
-
-                    float hitRMS   = hit2D->getHit()->RMS();
-                    float peakTime = hit2D->getTimeTicks();
-
-                    // Basically, allow the range to extend to the nearest end of the snippet
-                    if (hit2D->getHit()->DegreesOfFreedom() < 2) hitRMS *= m_LongHitStretchFctr;
-                        //hitRMS = std::min(hit2D->getTimeTicks() - float(hit2D->getHit()->StartTick()),float(hit2D->getHit()->EndTick())-hit2D->getTimeTicks());
-
-                    float weight = 1. / (hitRMS * hitRMS);
-
-                    avePeakTime += peakTime * weight;
-                    xPosition   += hit2D->getXPosition() * weight;
-                    weightSum   += weight;
-                }
-
-                avePeakTime /= weightSum;
-                xPosition   /= weightSum;
-
-                Eigen::Vector2f pair0hYZVec(pair0h.getPosition()[1],pair0h.getPosition()[2]);
-                Eigen::Vector2f pair1hYZVec(pair1h.getPosition()[1],pair1h.getPosition()[2]);
-                Eigen::Vector2f pairYZVec(pair.getPosition()[1],pair.getPosition()[2]);
-                Eigen::Vector3f position(xPosition,
-                                         float((pairYZVec[0] + pair0hYZVec[0] + pair1hYZVec[0]) / 3.),
-                                         float((pairYZVec[1] + pair0hYZVec[1] + pair1hYZVec[1]) / 3.));
-
-                // Armed with the average peak time, now get hitChiSquare and the sig vec
-                float              hitChiSquare(0.);
-                float              sigmaPeakTime(std::sqrt(1./weightSum));
-                std::vector<float> hitDelTSigVec;
-
-                for(const auto& hit2D : hitVector)
-                {
-                    float hitRMS = hit2D->getHit()->RMS();
-
-                    // Basically, allow the range to extend to the nearest end of the snippet
-                    if (hit2D->getHit()->DegreesOfFreedom() < 2) hitRMS *= m_LongHitStretchFctr;
-                        //hitRMS = std::min(hit2D->getTimeTicks() - float(hit2D->getHit()->StartTick()),float(hit2D->getHit()->EndTick())-hit2D->getTimeTicks());
-
-                    float combRMS   = std::sqrt(hitRMS*hitRMS - sigmaPeakTime*sigmaPeakTime);
-                    float peakTime  = hit2D->getTimeTicks();
-                    float deltaTime = peakTime - avePeakTime;
-                    float hitSig    = deltaTime / combRMS;
-
-                    hitChiSquare += hitSig * hitSig;
-
-                    hitDelTSigVec.emplace_back(std::fabs(hitSig));
-                }
-
-                if (m_outputHistograms) m_chiSquare3DVec.push_back(hitChiSquare);
-
-                int lowMinIndex(std::numeric_limits<int>::max());
-                int lowMaxIndex(std::numeric_limits<int>::min());
-                int hiMinIndex(std::numeric_limits<int>::max());
-                int hiMaxIndex(std::numeric_limits<int>::min());
-
-                // First task is to get the min/max values for the common overlap region
-                for(const auto& hit2D : hitVector)
-                {
-                    float range = m_rangeNumSig * hit2D->getHit()->RMS();
-
-                    // Basically, allow the range to extend to the nearest end of the snippet
-                    if (hit2D->getHit()->DegreesOfFreedom() < 2) range *= m_LongHitStretchFctr;
-                        //range = std::min(hit2D->getTimeTicks() - float(hit2D->getHit()->StartTick()),float(hit2D->getHit()->EndTick())-hit2D->getTimeTicks());
-
-                    int hitStart = hit2D->getHit()->PeakTime() - range - 0.5;
-                    int hitStop  = hit2D->getHit()->PeakTime() + range + 0.5;
-
-                    lowMinIndex = std::min(hitStart,    lowMinIndex);
-                    lowMaxIndex = std::max(hitStart,    lowMaxIndex);
-                    hiMinIndex  = std::min(hitStop + 1, hiMinIndex);
-                    hiMaxIndex  = std::max(hitStop + 1, hiMaxIndex);
-                }
-
-                // Keep only "good" hits...
-                if (hitChiSquare < m_maxHit3DChiSquare && hiMinIndex > lowMaxIndex)
-                {
-                    // One more pass through hits to get charge
-                    std::vector<float> chargeVec;
-
-                    for(const auto& hit2D : hitVector)
-                        chargeVec.push_back(chargeIntegral(hit2D->getHit()->PeakTime(),hit2D->getHit()->PeakAmplitude(),hit2D->getHit()->RMS(),1.,lowMaxIndex,hiMinIndex));
-
-                    float totalCharge     = std::accumulate(chargeVec.begin(),chargeVec.end(),0.) / float(chargeVec.size());
-                    float overlapRange    = float(hiMinIndex - lowMaxIndex);
-                    float overlapFraction = overlapRange / float(hiMaxIndex - lowMinIndex);
-
-                    // Set up to compute the charge asymmetry
-                    std::vector<float> smallestChargeDiffVec;
-                    std::vector<float> chargeAveVec;
-                    float              smallestDiff(std::numeric_limits<float>::max());
-                    float              maxDeltaPeak(0.);
-                    size_t             chargeIndex(0);
-
-                    for(size_t idx = 0; idx < 3; idx++)
-                    {
-                        size_t leftIdx  = (idx + 2) % 3;
-                        size_t rightIdx = (idx + 1) % 3;
-
-                        smallestChargeDiffVec.push_back(std::abs(chargeVec[leftIdx] - chargeVec[rightIdx]));
-                        chargeAveVec.push_back(float(0.5 * (chargeVec[leftIdx] + chargeVec[rightIdx])));
-
-                        if (smallestChargeDiffVec.back() < smallestDiff)
-                        {
-                            smallestDiff = smallestChargeDiffVec.back();
-                            chargeIndex  = idx;
-                        }
-
-                        // Take opportunity to look at peak time diff
-                        float deltaPeakTime = hitVector[rightIdx]->getTimeTicks() - hitVector[leftIdx]->getTimeTicks();
-
-                        if (std::abs(deltaPeakTime) > maxDeltaPeak) maxDeltaPeak = std::abs(deltaPeakTime);
-
-                        if (m_outputHistograms)
-                        {
-                            int   deltaTimeIdx = (hitVector[leftIdx]->WireID().Plane + hitVector[rightIdx]->WireID().Plane) - 1;
-                            float combRMS      = std::sqrt(std::pow(hitVector[leftIdx]->getHit()->RMS(),2) + std::pow(hitVector[rightIdx]->getHit()->RMS(),2));
-
-                            m_deltaTimeVec.push_back(deltaPeakTime);
-
-                            // Want to get the sign of the difference correct...
-                            if (deltaTimeIdx == 0)  // This is planes 1 and 0
-                            {
-                                m_deltaTime0Vec.emplace_back(float(hitVector[1]->getTimeTicks() - hitVector[0]->getTimeTicks()));
-                                m_deltaSigma0Vec.emplace_back(combRMS);
-                            }
-                            else if (deltaTimeIdx == 1)  // This is planes 0 and 2
-                            {
-                                m_deltaTime1Vec.emplace_back(float(hitVector[2]->getTimeTicks() - hitVector[0]->getTimeTicks()));
-                                m_deltaSigma1Vec.emplace_back(combRMS);
-                            }
-                            else // must be planes 1 and 2
-                            {
-                                m_deltaTime2Vec.emplace_back(float(hitVector[2]->getTimeTicks() - hitVector[1]->getTimeTicks()));
-                                m_deltaSigma2Vec.emplace_back(combRMS);
-                            }
-                        }
-                    }
-
-                    float chargeAsymmetry = (chargeAveVec[chargeIndex] - chargeVec[chargeIndex]) / (chargeAveVec[chargeIndex] + chargeVec[chargeIndex]);
-
-                    // If this is true there has to be a negative charge that snuck in somehow
-                    if (chargeAsymmetry < -1. || chargeAsymmetry > 1.)
-                    {
-                        const geo::WireID& hitWireID = hitVector[chargeIndex]->WireID();
-
-                        std::cout << "============> Charge asymmetry out of range: " << chargeAsymmetry << " <============" << std::endl;
-                        std::cout << "     hit C: " << hitWireID.Cryostat << ", TPC: " << hitWireID.TPC << ", Plane: " << hitWireID.Plane << ", Wire: " << hitWireID.Wire << std::endl;
-                        std::cout << "     charge: " << chargeVec[0] << ", " << chargeVec[1] << ", " << chargeVec[2] << std::endl;
-                        std::cout << "     index: " << chargeIndex << ", smallest diff: " << smallestDiff << std::endl;
-                        return result;
-                    }
-
-                    // Usurping "deltaPeakTime" to be the maximum pull
-                    float deltaPeakTime = *std::max_element(hitDelTSigVec.begin(),hitDelTSigVec.end());
-
-                    if (m_outputHistograms)
-                    {
-                        m_smallChargeDiffVec.push_back(smallestDiff);
-                        m_smallIndexVec.push_back(chargeIndex);
-                        m_maxPullVec.push_back(deltaPeakTime);
-                        m_qualityMetricVec.push_back(hitChiSquare);
-                        m_spacePointChargeVec.push_back(totalCharge);
-                        m_overlapFractionVec.push_back(overlapFraction);
-                        m_overlapRangeVec.push_back(overlapRange);
-                        m_maxDeltaPeakVec.push_back(maxDeltaPeak);
-                        m_hitAsymmetryVec.push_back(chargeAsymmetry);
-                    }
-
-                    // Try to weed out cases where overlap doesn't match peak separation
-                    if (maxDeltaPeak > 3. * overlapRange) return result;
-
-                    // Create the 3D cluster hit
-                    hitTriplet.initialize(0,
-                                          statusBits,
-                                          position,
-                                          totalCharge,
-                                          avePeakTime,
-                                          deltaPeakTime,
-                                          sigmaPeakTime,
-                                          hitChiSquare,
-                                          overlapFraction,
-                                          chargeAsymmetry,
-                                          0.,
-                                          0.,
-                                          hitVector,
-                                          hitDelTSigVec,
-                                          wireIDVec);
-
-                    // Since we are keeping the triplet, mark the hits as used
-                    for(size_t hit2DIdx = 0; hit2DIdx < hitVector.size(); hit2DIdx++)
-                    {
-                        const reco::ClusterHit2D* hit2D = hitVector[hit2DIdx];
-
-                        matchedHitMap[hit2D].insert(hitVector[(hit2DIdx+1)%hitVector.size()]);
-                        matchedHitMap[hit2D].insert(hitVector[(hit2DIdx+2)%hitVector.size()]);
-
-                        if (hit2D->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET) hit2D->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
-
-                        hit2D->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
-                    }
-
-                    // Mark the input pair
-                    pair.setStatusBit(reco::ClusterHit3D::MADESPACEPOINT);
-
-                    result = true;
-                }
-//                else mf::LogDebug("SnippetHit3D") << "-Rejecting triple with chiSquare: " << hitChiSquare << " and hiMinIndex: " << hiMinIndex << ", loMaxIndex: " << lowMaxIndex;
-            }
+            result = true;
+          }
+          //                else mf::LogDebug("SnippetHit3D") << "-Rejecting triple with chiSquare: " << hitChiSquare << " and hiMinIndex: " << hiMinIndex << ", loMaxIndex: " << lowMaxIndex;
         }
+      }
     }
-//    else mf::LogDebug("SnippetHit3D") << "-MakeTriplet hit cut, delta: " << hitTimeTicks - pair.getAvePeakTime() << ", min scale fctr: " <<m_hitWidthSclFctr << ", pair sig: " << pair.getSigmaPeakTime() << ", hitSigma: " << hitSigma << std::endl;
+    //    else mf::LogDebug("SnippetHit3D") << "-MakeTriplet hit cut, delta: " << hitTimeTicks - pair.getAvePeakTime() << ", min scale fctr: " <<m_hitWidthSclFctr << ", pair sig: " << pair.getSigmaPeakTime() << ", hitSigma: " << hitSigma << std::endl;
 
     // return success/fail
     return result;
-}
+  }
 
-bool SnippetHit3DBuilder::WireIDsIntersect(const geo::WireID& wireID0, const geo::WireID& wireID1, geo::WireIDIntersection& widIntersection) const
-{
+  bool SnippetHit3DBuilder::WireIDsIntersect(const geo::WireID& wireID0,
+                                             const geo::WireID& wireID1,
+                                             geo::WireIDIntersection& widIntersection) const
+  {
     bool success(false);
 
     // Do quick check that things are in the same logical TPC
-    if (wireID0.Cryostat != wireID1.Cryostat || wireID0.TPC != wireID1.TPC || wireID0.Plane == wireID1.Plane) return success;
-        
+    if (wireID0.Cryostat != wireID1.Cryostat || wireID0.TPC != wireID1.TPC ||
+        wireID0.Plane == wireID1.Plane)
+      return success;
+
     // Recover wire geometry information for each wire
     const geo::WireGeo& wireGeo0 = m_wireReadoutAlg->Wire(wireID0);
     const geo::WireGeo& wireGeo1 = m_wireReadoutAlg->Wire(wireID1);
@@ -1484,51 +1560,51 @@ bool SnippetHit3DBuilder::WireIDsIntersect(const geo::WireID& wireID0, const geo
     // Get wire position and direction for first wire
     auto wirePosArr = wireGeo0.GetCenter();
 
-    Eigen::Vector3f wirePos0(wirePosArr.X(),wirePosArr.Y(),wirePosArr.Z());
-    Eigen::Vector3f wireDir0(wireGeo0.Direction().X(),wireGeo0.Direction().Y(),wireGeo0.Direction().Z());
+    Eigen::Vector3f wirePos0(wirePosArr.X(), wirePosArr.Y(), wirePosArr.Z());
+    Eigen::Vector3f wireDir0(
+      wireGeo0.Direction().X(), wireGeo0.Direction().Y(), wireGeo0.Direction().Z());
 
     //*********************************
     // Kludge
-//    if (wireID0.Plane > 0) wireDir0[2] = -wireDir0[2];
+    //    if (wireID0.Plane > 0) wireDir0[2] = -wireDir0[2];
 
     // And now the second one
     wirePosArr = wireGeo1.GetCenter();
 
-    Eigen::Vector3f wirePos1(wirePosArr.X(),wirePosArr.Y(),wirePosArr.Z());
-    Eigen::Vector3f wireDir1(wireGeo1.Direction().X(),wireGeo1.Direction().Y(),wireGeo1.Direction().Z());
+    Eigen::Vector3f wirePos1(wirePosArr.X(), wirePosArr.Y(), wirePosArr.Z());
+    Eigen::Vector3f wireDir1(
+      wireGeo1.Direction().X(), wireGeo1.Direction().Y(), wireGeo1.Direction().Z());
 
     //**********************************
     // Kludge
-//    if (wireID1.Plane > 0) wireDir1[2] = -wireDir1[2];
+    //    if (wireID1.Plane > 0) wireDir1[2] = -wireDir1[2];
 
     // Get the distance of closest approach
     float arcLen0;
     float arcLen1;
 
-    if (closestApproach(wirePos0, wireDir0, wirePos1, wireDir1, arcLen0, arcLen1))
-    {
-        // Now check that arc lengths are within range
-        if (std::abs(arcLen0) < wireGeo0.HalfL() && std::abs(arcLen1) < wireGeo1.HalfL())
-        {
-            Eigen::Vector3f poca0 = wirePos0 + arcLen0 * wireDir0;
+    if (closestApproach(wirePos0, wireDir0, wirePos1, wireDir1, arcLen0, arcLen1)) {
+      // Now check that arc lengths are within range
+      if (std::abs(arcLen0) < wireGeo0.HalfL() && std::abs(arcLen1) < wireGeo1.HalfL()) {
+        Eigen::Vector3f poca0 = wirePos0 + arcLen0 * wireDir0;
 
-            widIntersection.y = poca0[1];
-            widIntersection.z = poca0[2];
+        widIntersection.y = poca0[1];
+        widIntersection.z = poca0[2];
 
-            success = true;
-        }
+        success = true;
+      }
     }
 
     return success;
-}
+  }
 
-float SnippetHit3DBuilder::closestApproach(const Eigen::Vector3f& P0,
-                                                 const Eigen::Vector3f& u0,
-                                                 const Eigen::Vector3f& P1,
-                                                 const Eigen::Vector3f& u1,
-                                                 float&                 arcLen0,
-                                                 float&                 arcLen1) const
-{
+  float SnippetHit3DBuilder::closestApproach(const Eigen::Vector3f& P0,
+                                             const Eigen::Vector3f& u0,
+                                             const Eigen::Vector3f& P1,
+                                             const Eigen::Vector3f& u1,
+                                             float& arcLen0,
+                                             float& arcLen1) const
+  {
     // Technique is to compute the arclength to each point of closest approach
     Eigen::Vector3f w0 = P0 - P1;
     float a(1.);
@@ -1545,28 +1621,30 @@ float SnippetHit3DBuilder::closestApproach(const Eigen::Vector3f& P0,
     Eigen::Vector3f poca1 = P1 + arcLen1 * u1;
 
     return (poca0 - poca1).norm();
-}
+  }
 
-float SnippetHit3DBuilder::chargeIntegral(float peakMean,
-                                           float peakAmp,
-                                           float peakSigma,
-                                           float areaNorm,
-                                           int   low,
-                                           int   hi) const
-{
+  float SnippetHit3DBuilder::chargeIntegral(float peakMean,
+                                            float peakAmp,
+                                            float peakSigma,
+                                            float areaNorm,
+                                            int low,
+                                            int hi) const
+  {
     float integral(0);
 
-    for(int sigPos = low; sigPos < hi; sigPos++)
-    {
-        float arg = (float(sigPos) - peakMean + 0.5) / peakSigma;
-        integral += peakAmp * std::exp(-0.5 * arg * arg);
+    for (int sigPos = low; sigPos < hi; sigPos++) {
+      float arg = (float(sigPos) - peakMean + 0.5) / peakSigma;
+      integral += peakAmp * std::exp(-0.5 * arg * arg);
     }
 
     return integral;
-}
+  }
 
-const reco::ClusterHit2D* SnippetHit3DBuilder::FindBestMatchingHit(const Hit2DSet& hit2DSet, const reco::ClusterHit3D& pair, float pairDeltaTimeLimits) const
-{
+  const reco::ClusterHit2D* SnippetHit3DBuilder::FindBestMatchingHit(
+    const Hit2DSet& hit2DSet,
+    const reco::ClusterHit3D& pair,
+    float pairDeltaTimeLimits) const
+  {
     static const float minCharge(0.);
 
     const reco::ClusterHit2D* bestVHit(0);
@@ -1574,136 +1652,138 @@ const reco::ClusterHit2D* SnippetHit3DBuilder::FindBestMatchingHit(const Hit2DSe
     float pairAvePeakTime(pair.getAvePeakTime());
 
     // Idea is to loop through the input set of hits and look for the best combination
-    for (const auto& hit2D : hit2DSet)
-    {
-        if (hit2D->getHit()->Integral() < minCharge) continue;
+    for (const auto& hit2D : hit2DSet) {
+      if (hit2D->getHit()->Integral() < minCharge) continue;
 
-        float hitVPeakTime(hit2D->getTimeTicks());
-        float deltaPeakTime(pairAvePeakTime-hitVPeakTime);
+      float hitVPeakTime(hit2D->getTimeTicks());
+      float deltaPeakTime(pairAvePeakTime - hitVPeakTime);
 
-        if (deltaPeakTime >  pairDeltaTimeLimits) continue;
+      if (deltaPeakTime > pairDeltaTimeLimits) continue;
 
-        if (deltaPeakTime < -pairDeltaTimeLimits) break;
+      if (deltaPeakTime < -pairDeltaTimeLimits) break;
 
-        pairDeltaTimeLimits = fabs(deltaPeakTime);
-        bestVHit            = hit2D;
+      pairDeltaTimeLimits = fabs(deltaPeakTime);
+      bestVHit = hit2D;
     }
 
     return bestVHit;
-}
+  }
 
-int SnippetHit3DBuilder::FindNumberInRange(const Hit2DSet& hit2DSet, const reco::ClusterHit3D& pair, float range) const
-{
+  int SnippetHit3DBuilder::FindNumberInRange(const Hit2DSet& hit2DSet,
+                                             const reco::ClusterHit3D& pair,
+                                             float range) const
+  {
     static const float minCharge(0.);
 
-    int    numberInRange(0);
+    int numberInRange(0);
     float pairAvePeakTime(pair.getAvePeakTime());
 
     // Idea is to loop through the input set of hits and look for the best combination
-    for (const auto& hit2D : hit2DSet)
-    {
-        if (hit2D->getHit()->Integral() < minCharge) continue;
+    for (const auto& hit2D : hit2DSet) {
+      if (hit2D->getHit()->Integral() < minCharge) continue;
 
-        float hitVPeakTime(hit2D->getTimeTicks());
-        float deltaPeakTime(pairAvePeakTime-hitVPeakTime);
+      float hitVPeakTime(hit2D->getTimeTicks());
+      float deltaPeakTime(pairAvePeakTime - hitVPeakTime);
 
-        if (deltaPeakTime >  range) continue;
+      if (deltaPeakTime > range) continue;
 
-        if (deltaPeakTime < -range) break;
+      if (deltaPeakTime < -range) break;
 
-        numberInRange++;
+      numberInRange++;
     }
 
     return numberInRange;
-}
+  }
 
-geo::WireID SnippetHit3DBuilder::NearestWireID(const Eigen::Vector3f& position, const geo::WireID& wireIDIn) const
-{
+  geo::WireID SnippetHit3DBuilder::NearestWireID(const Eigen::Vector3f& position,
+                                                 const geo::WireID& wireIDIn) const
+  {
     int wire(0);
 
     // Embed the call to the geometry's services nearest wire id method in a try-catch block
-    try
-    {
-        // Not sure the thinking above but is wrong... switch back to NearestWireID...
-        wire = (m_wireReadoutAlg->NearestWireID(geo::vect::toPoint(position.data()),wireIDIn)).Wire;
+    try {
+      // Not sure the thinking above but is wrong... switch back to NearestWireID...
+      wire = (m_wireReadoutAlg->NearestWireID(geo::vect::toPoint(position.data()), wireIDIn)).Wire;
     }
-    catch(std::exception& exc) 
-    {
-        // This can happen, almost always because the coordinates are **just** out of range
-        mf::LogDebug("Cluster3D") << "Exception caught finding nearest wire, position - " << exc.what() << std::endl;
+    catch (std::exception& exc) {
+      // This can happen, almost always because the coordinates are **just** out of range
+      mf::LogDebug("Cluster3D") << "Exception caught finding nearest wire, position - "
+                                << exc.what() << std::endl;
 
-        // Assume extremum for wire number depending on z coordinate
-        if (position[2] < m_geometry->TPC({0,0}).ActiveLength()*0.5) wire = 0;
-        else                                              wire = m_wireReadoutAlg->Nwires(wireIDIn.asPlaneID()) - 1;
+      // Assume extremum for wire number depending on z coordinate
+      if (position[2] < m_geometry->TPC({0, 0}).ActiveLength() * 0.5)
+        wire = 0;
+      else
+        wire = m_wireReadoutAlg->Nwires(wireIDIn.asPlaneID()) - 1;
     }
 
-    geo::WireID wireID(wireIDIn.Cryostat,wireIDIn.TPC,wireIDIn.Plane,wire);
+    geo::WireID wireID(wireIDIn.Cryostat, wireIDIn.TPC, wireIDIn.Plane, wire);
 
     return wireID;
-}
+  }
 
-float SnippetHit3DBuilder::DistanceFromPointToHitWire(const Eigen::Vector3f& position, const geo::WireID& wireIDIn) const
-{
+  float SnippetHit3DBuilder::DistanceFromPointToHitWire(const Eigen::Vector3f& position,
+                                                        const geo::WireID& wireIDIn) const
+  {
     float distance = std::numeric_limits<float>::max();
 
     // Embed the call to the geometry's services nearest wire id method in a try-catch block
-    try
-    {
-        // Recover wire geometry information for each wire
-        const geo::WireGeo& wireGeo = m_wireReadoutAlg->Wire(wireIDIn);
+    try {
+      // Recover wire geometry information for each wire
+      const geo::WireGeo& wireGeo = m_wireReadoutAlg->Wire(wireIDIn);
 
-        // Get wire position and direction for first wire
-        auto const wirePosArr = wireGeo.GetCenter();
+      // Get wire position and direction for first wire
+      auto const wirePosArr = wireGeo.GetCenter();
 
-        Eigen::Vector3f wirePos(wirePosArr.X(),wirePosArr.Y(),wirePosArr.Z());
-        Eigen::Vector3f wireDir(wireGeo.Direction().X(),wireGeo.Direction().Y(),wireGeo.Direction().Z());
+      Eigen::Vector3f wirePos(wirePosArr.X(), wirePosArr.Y(), wirePosArr.Z());
+      Eigen::Vector3f wireDir(
+        wireGeo.Direction().X(), wireGeo.Direction().Y(), wireGeo.Direction().Z());
 
-        //*********************************
-        // Kludge
-//        if (wireIDIn.Plane > 0) wireDir[2] = -wireDir[2];
+      //*********************************
+      // Kludge
+      //        if (wireIDIn.Plane > 0) wireDir[2] = -wireDir[2];
 
+      // Want the hit position to have same x value as wire coordinates
+      Eigen::Vector3f hitPosition(wirePos[0], position[1], position[2]);
 
-        // Want the hit position to have same x value as wire coordinates
-        Eigen::Vector3f hitPosition(wirePos[0],position[1],position[2]);
+      // Get arc length to doca
+      double arcLen = (hitPosition - wirePos).dot(wireDir);
 
-        // Get arc length to doca
-        double arcLen = (hitPosition - wirePos).dot(wireDir);
+      // Make sure arclen is in range
+      if (abs(arcLen) < wireGeo.HalfL()) {
+        Eigen::Vector3f docaVec = hitPosition - (wirePos + arcLen * wireDir);
 
-        // Make sure arclen is in range
-        if (abs(arcLen) < wireGeo.HalfL())
-        {
-            Eigen::Vector3f docaVec = hitPosition - (wirePos + arcLen * wireDir);
-
-            distance = docaVec.norm();
-        }
+        distance = docaVec.norm();
+      }
     }
-    catch(std::exception& exc)
-    {
-        // This can happen, almost always because the coordinates are **just** out of range
-        mf::LogWarning("Cluster3D") << "Exception caught finding nearest wire, position - " << exc.what() << std::endl;
+    catch (std::exception& exc) {
+      // This can happen, almost always because the coordinates are **just** out of range
+      mf::LogWarning("Cluster3D") << "Exception caught finding nearest wire, position - "
+                                  << exc.what() << std::endl;
 
-        // Assume extremum for wire number depending on z coordinate
-        distance = 0.;
+      // Assume extremum for wire number depending on z coordinate
+      distance = 0.;
     }
 
     return distance;
-}
+  }
 
-//------------------------------------------------------------------------------------------------------------------------------------------
-bool SetHitTimeOrder(const reco::ClusterHit2D* left, const reco::ClusterHit2D* right)
-{
+  //------------------------------------------------------------------------------------------------------------------------------------------
+  bool SetHitTimeOrder(const reco::ClusterHit2D* left, const reco::ClusterHit2D* right)
+  {
     // Sort by "modified start time" of pulse
     return left->getHit()->PeakTime() < right->getHit()->PeakTime();
-}
+  }
 
-bool Hit2DSetCompare::operator() (const reco::ClusterHit2D* left, const reco::ClusterHit2D* right) const
-{
+  bool Hit2DSetCompare::operator()(const reco::ClusterHit2D* left,
+                                   const reco::ClusterHit2D* right) const
+  {
     return left->getHit()->PeakTime() < right->getHit()->PeakTime();
-}
+  }
 
-//------------------------------------------------------------------------------------------------------------------------------------------
-void SnippetHit3DBuilder::CollectArtHits(const art::Event& evt) const
-{
+  //------------------------------------------------------------------------------------------------------------------------------------------
+  void SnippetHit3DBuilder::CollectArtHits(const art::Event& evt) const
+  {
     /**
      *  @brief Recover the 2D hits from art and fill out the local data structures for the 3D clustering
      */
@@ -1713,16 +1793,16 @@ void SnippetHit3DBuilder::CollectArtHits(const art::Event& evt) const
     std::vector<const recob::Hit*> recobHitVec;
 
     // Loop through the list of input sources
-    for(const auto& inputTag : m_hitFinderTagVec)
-    {
-        art::Handle< std::vector<recob::Hit> > recobHitHandle;
-        evt.getByLabel(inputTag, recobHitHandle);
+    for (const auto& inputTag : m_hitFinderTagVec) {
+      art::Handle<std::vector<recob::Hit>> recobHitHandle;
+      evt.getByLabel(inputTag, recobHitHandle);
 
-        if (!recobHitHandle.isValid() || recobHitHandle->size() == 0) continue;
+      if (!recobHitHandle.isValid() || recobHitHandle->size() == 0) continue;
 
-        recobHitVec.reserve(recobHitVec.size() + recobHitHandle->size());
+      recobHitVec.reserve(recobHitVec.size() + recobHitHandle->size());
 
-        for(const auto& hit : *recobHitHandle) recobHitVec.push_back(&hit);
+      for (const auto& hit : *recobHitHandle)
+        recobHitVec.push_back(&hit);
     }
 
     // If the vector is empty there is nothing to do
@@ -1733,121 +1813,133 @@ void SnippetHit3DBuilder::CollectArtHits(const art::Event& evt) const
     if (m_enableMonitoring) theClockMakeHits.start();
 
     // Need the detector properties which needs the clocks
-    auto const clock_data = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
-    auto const det_prop   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clock_data);
+    auto const clock_data =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+    auto const det_prop =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clock_data);
 
     // Try to output a formatted string
     std::string debugMessage("");
 
     // Keep track of x position limits
-    std::map<geo::PlaneID,double> planeIDToPositionMap;
+    std::map<geo::PlaneID, double> planeIDToPositionMap;
 
     // Initialize the plane to hit vector map
-    for(size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++)
-    {
-        for(size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++)
-        {
-            m_planeToSnippetHitMap[geo::PlaneID(cryoIdx,tpcIdx,0)] = SnippetHitMap();
-            m_planeToSnippetHitMap[geo::PlaneID(cryoIdx,tpcIdx,1)] = SnippetHitMap();
-            m_planeToSnippetHitMap[geo::PlaneID(cryoIdx,tpcIdx,2)] = SnippetHitMap();
+    for (size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++) {
+      for (size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++) {
+        m_planeToSnippetHitMap[geo::PlaneID(cryoIdx, tpcIdx, 0)] = SnippetHitMap();
+        m_planeToSnippetHitMap[geo::PlaneID(cryoIdx, tpcIdx, 1)] = SnippetHitMap();
+        m_planeToSnippetHitMap[geo::PlaneID(cryoIdx, tpcIdx, 2)] = SnippetHitMap();
 
-            // Should we provide output?
-            if (!m_weHaveAllBeenHereBefore)
-            {
-                std::ostringstream outputString;
+        // Should we provide output?
+        if (!m_weHaveAllBeenHereBefore) {
+          std::ostringstream outputString;
 
-                outputString << "***> plane 0 offset: " << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx,tpcIdx,0))->second
-                             << ", plane 1: " << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx,tpcIdx,1))->second
-                             << ", plane    2: " << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx,tpcIdx,2))->second << "\n";
-                outputString << "     Det prop plane 0: " << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,0)) << ", plane 1: "  << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,1)) << ", plane 2: " << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,2)) << ", Trig: " << trigger_offset(clock_data) << "\n";
-                debugMessage += outputString.str() + "\n";
-            }
-
-            double xPosition(det_prop.ConvertTicksToX(0., 2, tpcIdx, cryoIdx));
-
-            planeIDToPositionMap[geo::PlaneID(cryoIdx,tpcIdx,2)] = xPosition;
+          outputString << "***> plane 0 offset: "
+                       << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx, tpcIdx, 0))->second
+                       << ", plane 1: "
+                       << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx, tpcIdx, 1))->second
+                       << ", plane    2: "
+                       << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx, tpcIdx, 2))->second
+                       << "\n";
+          outputString << "     Det prop plane 0: "
+                       << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 0))
+                       << ", plane 1: "
+                       << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 1))
+                       << ", plane 2: "
+                       << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 2))
+                       << ", Trig: " << trigger_offset(clock_data) << "\n";
+          debugMessage += outputString.str() + "\n";
         }
+
+        double xPosition(det_prop.ConvertTicksToX(0., 2, tpcIdx, cryoIdx));
+
+        planeIDToPositionMap[geo::PlaneID(cryoIdx, tpcIdx, 2)] = xPosition;
+      }
     }
 
-    if (!m_weHaveAllBeenHereBefore)
-    {
-        for(const auto& planeToPositionPair : planeIDToPositionMap)
-        {
-            std::ostringstream outputString;
+    if (!m_weHaveAllBeenHereBefore) {
+      for (const auto& planeToPositionPair : planeIDToPositionMap) {
+        std::ostringstream outputString;
 
-            outputString << "***> Plane " << planeToPositionPair.first << " has time=0 position: " << planeToPositionPair.second << "\n";
+        outputString << "***> Plane " << planeToPositionPair.first
+                     << " has time=0 position: " << planeToPositionPair.second << "\n";
 
-            debugMessage += outputString.str();
-        }
+        debugMessage += outputString.str();
+      }
 
-        mf::LogDebug("SnippetHit3D") << debugMessage << std::endl;
+      mf::LogDebug("SnippetHit3D") << debugMessage << std::endl;
 
-        m_weHaveAllBeenHereBefore = true;
+      m_weHaveAllBeenHereBefore = true;
     }
 
     // Cycle through the recob hits to build ClusterHit2D objects and insert
     // them into the map
-    for (const auto& recobHit : recobHitVec)
-    {
-        // Reject hits with negative charge, these are misreconstructed
-        if (recobHit->Integral() < 0.) continue;
+    for (const auto& recobHit : recobHitVec) {
+      // Reject hits with negative charge, these are misreconstructed
+      if (recobHit->Integral() < 0.) continue;
 
-        // For some detectors we can have multiple wire ID's associated to a given channel.
-        // So we recover the list of these wire IDs
-        const std::vector<geo::WireID>& wireIDs = m_wireReadoutAlg->ChannelToWire(recobHit->Channel());
+      // For some detectors we can have multiple wire ID's associated to a given channel.
+      // So we recover the list of these wire IDs
+      const std::vector<geo::WireID>& wireIDs =
+        m_wireReadoutAlg->ChannelToWire(recobHit->Channel());
 
-        // Start/End ticks to identify the snippet
-        HitStartEndPair hitStartEndPair(recobHit->StartTick(),recobHit->EndTick());
+      // Start/End ticks to identify the snippet
+      HitStartEndPair hitStartEndPair(recobHit->StartTick(), recobHit->EndTick());
 
-        // Can this really happen?
-        if (hitStartEndPair.second <= hitStartEndPair.first)
-        {
-            mf::LogDebug("SnippetHit3D") << "Yes, found a hit with end time less than start time: " << hitStartEndPair.first << "/" << hitStartEndPair.second << ", mult: " << recobHit->Multiplicity();
-            continue;
-        }
+      // Can this really happen?
+      if (hitStartEndPair.second <= hitStartEndPair.first) {
+        mf::LogDebug("SnippetHit3D")
+          << "Yes, found a hit with end time less than start time: " << hitStartEndPair.first << "/"
+          << hitStartEndPair.second << ", mult: " << recobHit->Multiplicity();
+        continue;
+      }
 
-        // And then loop over all possible to build out our maps
-        //for(const auto& wireID : wireIDs)
-        for(auto wireID : wireIDs)
-        {
-            // Check if this is an invalid TPC
-            // (for example, in protoDUNE there are logical TPC's which see no signal)
-            if (std::find(m_invalidTPCVec.begin(),m_invalidTPCVec.end(),wireID.TPC) != m_invalidTPCVec.end()) continue;
+      // And then loop over all possible to build out our maps
+      //for(const auto& wireID : wireIDs)
+      for (auto wireID : wireIDs) {
+        // Check if this is an invalid TPC
+        // (for example, in protoDUNE there are logical TPC's which see no signal)
+        if (std::find(m_invalidTPCVec.begin(), m_invalidTPCVec.end(), wireID.TPC) !=
+            m_invalidTPCVec.end())
+          continue;
 
-            // Note that a plane ID will define cryostat, TPC and plane
-            const geo::PlaneID& planeID = wireID.planeID();
+        // Note that a plane ID will define cryostat, TPC and plane
+        const geo::PlaneID& planeID = wireID.planeID();
 
-            double hitPeakTime(recobHit->PeakTime() - m_PlaneToT0OffsetMap.find(planeID)->second);
-            double xPosition(det_prop.ConvertTicksToX(recobHit->PeakTime(), planeID.Plane, planeID.TPC, planeID.Cryostat));
+        double hitPeakTime(recobHit->PeakTime() - m_PlaneToT0OffsetMap.find(planeID)->second);
+        double xPosition(det_prop.ConvertTicksToX(
+          recobHit->PeakTime(), planeID.Plane, planeID.TPC, planeID.Cryostat));
 
-            m_clusterHit2DMasterList.emplace_back(0, 0., 0., xPosition, hitPeakTime, wireID, recobHit);
+        m_clusterHit2DMasterList.emplace_back(0, 0., 0., xPosition, hitPeakTime, wireID, recobHit);
 
-            m_planeToSnippetHitMap[planeID][hitStartEndPair].emplace_back(&m_clusterHit2DMasterList.back());
-            m_planeToWireToHitSetMap[planeID][wireID.Wire].insert(&m_clusterHit2DMasterList.back());
-        }
+        m_planeToSnippetHitMap[planeID][hitStartEndPair].emplace_back(
+          &m_clusterHit2DMasterList.back());
+        m_planeToWireToHitSetMap[planeID][wireID.Wire].insert(&m_clusterHit2DMasterList.back());
+      }
     }
 
     // Make a loop through to sort the recover hits in time order
-//    for(auto& hitVectorMap : m_planeToSnippetHitMap)
-//        std::sort(hitVectorMap.second.begin(), hitVectorMap.second.end(), SetHitTimeOrder);
+    //    for(auto& hitVectorMap : m_planeToSnippetHitMap)
+    //        std::sort(hitVectorMap.second.begin(), hitVectorMap.second.end(), SetHitTimeOrder);
 
-    if (m_enableMonitoring)
-    {
-        theClockMakeHits.stop();
+    if (m_enableMonitoring) {
+      theClockMakeHits.stop();
 
-        m_timeVector[COLLECTARTHITS] = theClockMakeHits.accumulated_real_time();
+      m_timeVector[COLLECTARTHITS] = theClockMakeHits.accumulated_real_time();
     }
 
-    mf::LogDebug("SnippetHit3D") << ">>>>> Number of ART hits: " << m_clusterHit2DMasterList.size() << std::endl;
-}
+    mf::LogDebug("SnippetHit3D") << ">>>>> Number of ART hits: " << m_clusterHit2DMasterList.size()
+                                 << std::endl;
+  }
 
-//------------------------------------------------------------------------------------------------------------------------------------------
+  //------------------------------------------------------------------------------------------------------------------------------------------
 
-void SnippetHit3DBuilder::CreateNewRecobHitCollection(art::Event&              event,
-                                                            reco::HitPairList&       hitPairList,
-                                                            std::vector<recob::Hit>& hitPtrVec,
-                                                            RecobHitToPtrMap&        recobHitToPtrMap)
-{
+  void SnippetHit3DBuilder::CreateNewRecobHitCollection(art::Event& event,
+                                                        reco::HitPairList& hitPairList,
+                                                        std::vector<recob::Hit>& hitPtrVec,
+                                                        RecobHitToPtrMap& recobHitToPtrMap)
+  {
     // Set up the timing
     cet::cpu_timer theClockBuildNewHits;
 
@@ -1866,53 +1958,53 @@ void SnippetHit3DBuilder::CreateNewRecobHitCollection(art::Event&              e
     hitPtrVec.reserve(m_clusterHit2DMasterList.size());
 
     // Scheme is to loop through all 3D hits, then through each associated ClusterHit2D object
-    for(reco::ClusterHit3D& hit3D : hitPairList)
-    {
-        reco::ClusterHit2DVec& hit2DVec = hit3D.getHits();
+    for (reco::ClusterHit3D& hit3D : hitPairList) {
+      reco::ClusterHit2DVec& hit2DVec = hit3D.getHits();
 
-        // The loop is over the index so we can recover the correct WireID to associate to the new hit when made
-        for(size_t idx = 0; idx < hit3D.getHits().size(); idx++)
-        {
-            const reco::ClusterHit2D* hit2D = hit2DVec[idx];
+      // The loop is over the index so we can recover the correct WireID to associate to the new hit when made
+      for (size_t idx = 0; idx < hit3D.getHits().size(); idx++) {
+        const reco::ClusterHit2D* hit2D = hit2DVec[idx];
 
-            if (!hit2D) continue;
+        if (!hit2D) continue;
 
-            // Have we seen this 2D hit already?
-            if (visitedHit2DSet.find(hit2D) == visitedHit2DSet.end())
-            {
-                visitedHit2DSet.insert(hit2D);
+        // Have we seen this 2D hit already?
+        if (visitedHit2DSet.find(hit2D) == visitedHit2DSet.end()) {
+          visitedHit2DSet.insert(hit2D);
 
-                // Create and save the new recob::Hit with the correct WireID
-                hitPtrVec.emplace_back(recob::HitCreator(*hit2D->getHit(), hit3D.getWireIDs()[idx]).copy());
+          // Create and save the new recob::Hit with the correct WireID
+          hitPtrVec.emplace_back(
+            recob::HitCreator(*hit2D->getHit(), hit3D.getWireIDs()[idx]).copy());
 
-                // Recover a pointer to it...
-                recob::Hit* newHit = &hitPtrVec.back();
+          // Recover a pointer to it...
+          recob::Hit* newHit = &hitPtrVec.back();
 
-                // Create a mapping from this hit to an art Ptr representing it
-                recobHitToPtrMap[newHit] = ptrMaker(hitPtrVec.size()-1);
+          // Create a mapping from this hit to an art Ptr representing it
+          recobHitToPtrMap[newHit] = ptrMaker(hitPtrVec.size() - 1);
 
-                // And set the pointer to this hit in the ClusterHit2D object
-                const_cast<reco::ClusterHit2D*>(hit2D)->setHit(newHit);
-            }
+          // And set the pointer to this hit in the ClusterHit2D object
+          const_cast<reco::ClusterHit2D*>(hit2D)->setHit(newHit);
         }
+      }
     }
 
     size_t numNewHits = hitPtrVec.size();
 
-    if (m_enableMonitoring)
-    {
-        theClockBuildNewHits.stop();
+    if (m_enableMonitoring) {
+      theClockBuildNewHits.stop();
 
-        m_timeVector[BUILDNEWHITS] = theClockBuildNewHits.accumulated_real_time();
+      m_timeVector[BUILDNEWHITS] = theClockBuildNewHits.accumulated_real_time();
     }
 
-    mf::LogDebug("SnippetHit3D") << ">>>>> New output recob::Hit size: " << numNewHits << " (vs " << m_clusterHit2DMasterList.size() << " input)" << std::endl;
+    mf::LogDebug("SnippetHit3D") << ">>>>> New output recob::Hit size: " << numNewHits << " (vs "
+                                 << m_clusterHit2DMasterList.size() << " input)" << std::endl;
 
     return;
-}
+  }
 
-void SnippetHit3DBuilder::makeWireAssns(const art::Event& evt, art::Assns<recob::Wire, recob::Hit>& wireAssns, RecobHitToPtrMap& recobHitPtrMap) const
-{
+  void SnippetHit3DBuilder::makeWireAssns(const art::Event& evt,
+                                          art::Assns<recob::Wire, recob::Hit>& wireAssns,
+                                          RecobHitToPtrMap& recobHitPtrMap) const
+  {
     // Let's make sure the input associations container is empty
     wireAssns = art::Assns<recob::Wire, recob::Hit>();
 
@@ -1921,44 +2013,43 @@ void SnippetHit3DBuilder::makeWireAssns(const art::Event& evt, art::Assns<recob:
     std::unordered_map<raw::ChannelID_t, art::Ptr<recob::Wire>> channelToWireMap;
 
     // Go through the list of input sources and fill out the map
-    for(const auto& inputTag : m_hitFinderTagVec)
-    {
-        art::ValidHandle<std::vector<recob::Hit>> hitHandle = evt.getValidHandle<std::vector<recob::Hit>>(inputTag);
+    for (const auto& inputTag : m_hitFinderTagVec) {
+      art::ValidHandle<std::vector<recob::Hit>> hitHandle =
+        evt.getValidHandle<std::vector<recob::Hit>>(inputTag);
 
-        art::FindOneP<recob::Wire> hitToWireAssns(hitHandle, evt, inputTag);
+      art::FindOneP<recob::Wire> hitToWireAssns(hitHandle, evt, inputTag);
 
-        if (hitToWireAssns.isValid())
-        {
-            for(size_t wireIdx = 0; wireIdx < hitToWireAssns.size(); wireIdx++)
-            {
-                art::Ptr<recob::Wire> wire = hitToWireAssns.at(wireIdx);
+      if (hitToWireAssns.isValid()) {
+        for (size_t wireIdx = 0; wireIdx < hitToWireAssns.size(); wireIdx++) {
+          art::Ptr<recob::Wire> wire = hitToWireAssns.at(wireIdx);
 
-                channelToWireMap[wire->Channel()] = wire;
-            }
+          channelToWireMap[wire->Channel()] = wire;
         }
+      }
     }
 
     // Now fill the container
-    for(const auto& hitPtrPair : recobHitPtrMap)
-    {
-        raw::ChannelID_t channel = hitPtrPair.first->Channel();
+    for (const auto& hitPtrPair : recobHitPtrMap) {
+      raw::ChannelID_t channel = hitPtrPair.first->Channel();
 
-        std::unordered_map<raw::ChannelID_t, art::Ptr<recob::Wire>>::iterator chanWireItr = channelToWireMap.find(channel);
+      std::unordered_map<raw::ChannelID_t, art::Ptr<recob::Wire>>::iterator chanWireItr =
+        channelToWireMap.find(channel);
 
-        if (!(chanWireItr != channelToWireMap.end()))
-        {
-            //mf::LogDebug("SnippetHit3D") << "** Did not find channel to wire match! Skipping..." << std::endl;
-            continue;
-        }
+      if (!(chanWireItr != channelToWireMap.end())) {
+        //mf::LogDebug("SnippetHit3D") << "** Did not find channel to wire match! Skipping..." << std::endl;
+        continue;
+      }
 
-        wireAssns.addSingle(chanWireItr->second, hitPtrPair.second);
+      wireAssns.addSingle(chanWireItr->second, hitPtrPair.second);
     }
 
     return;
-}
+  }
 
-void SnippetHit3DBuilder::makeRawDigitAssns(const art::Event& evt, art::Assns<raw::RawDigit, recob::Hit>& rawDigitAssns, RecobHitToPtrMap& recobHitPtrMap) const
-{
+  void SnippetHit3DBuilder::makeRawDigitAssns(const art::Event& evt,
+                                              art::Assns<raw::RawDigit, recob::Hit>& rawDigitAssns,
+                                              RecobHitToPtrMap& recobHitPtrMap) const
+  {
     // Let's make sure the input associations container is empty
     rawDigitAssns = art::Assns<raw::RawDigit, recob::Hit>();
 
@@ -1967,43 +2058,40 @@ void SnippetHit3DBuilder::makeRawDigitAssns(const art::Event& evt, art::Assns<ra
     std::unordered_map<raw::ChannelID_t, art::Ptr<raw::RawDigit>> channelToRawDigitMap;
 
     // Go through the list of input sources and fill out the map
-    for(const auto& inputTag : m_hitFinderTagVec)
-    {
-        art::ValidHandle<std::vector<recob::Hit>> hitHandle = evt.getValidHandle<std::vector<recob::Hit>>(inputTag);
+    for (const auto& inputTag : m_hitFinderTagVec) {
+      art::ValidHandle<std::vector<recob::Hit>> hitHandle =
+        evt.getValidHandle<std::vector<recob::Hit>>(inputTag);
 
-        art::FindOneP<raw::RawDigit> hitToRawDigitAssns(hitHandle, evt, inputTag);
+      art::FindOneP<raw::RawDigit> hitToRawDigitAssns(hitHandle, evt, inputTag);
 
-        if (hitToRawDigitAssns.isValid())
-        {
-            for(size_t rawDigitIdx = 0; rawDigitIdx < hitToRawDigitAssns.size(); rawDigitIdx++)
-            {
-                art::Ptr<raw::RawDigit> rawDigit = hitToRawDigitAssns.at(rawDigitIdx);
+      if (hitToRawDigitAssns.isValid()) {
+        for (size_t rawDigitIdx = 0; rawDigitIdx < hitToRawDigitAssns.size(); rawDigitIdx++) {
+          art::Ptr<raw::RawDigit> rawDigit = hitToRawDigitAssns.at(rawDigitIdx);
 
-                channelToRawDigitMap[rawDigit->Channel()] = rawDigit;
-            }
+          channelToRawDigitMap[rawDigit->Channel()] = rawDigit;
         }
+      }
     }
 
     // Now fill the container
-    for(const auto& hitPtrPair : recobHitPtrMap)
-    {
-        raw::ChannelID_t channel = hitPtrPair.first->Channel();
+    for (const auto& hitPtrPair : recobHitPtrMap) {
+      raw::ChannelID_t channel = hitPtrPair.first->Channel();
 
-        std::unordered_map<raw::ChannelID_t, art::Ptr<raw::RawDigit>>::iterator chanRawDigitItr = channelToRawDigitMap.find(channel);
+      std::unordered_map<raw::ChannelID_t, art::Ptr<raw::RawDigit>>::iterator chanRawDigitItr =
+        channelToRawDigitMap.find(channel);
 
-        if (chanRawDigitItr == channelToRawDigitMap.end())
-        {
-            //mf::LogDebug("SnippetHit3D") << "** Did not find channel to wire match! Skipping..." << std::endl;
-           continue;
-        }
+      if (chanRawDigitItr == channelToRawDigitMap.end()) {
+        //mf::LogDebug("SnippetHit3D") << "** Did not find channel to wire match! Skipping..." << std::endl;
+        continue;
+      }
 
-        rawDigitAssns.addSingle(chanRawDigitItr->second, hitPtrPair.second);
+      rawDigitAssns.addSingle(chanRawDigitItr->second, hitPtrPair.second);
     }
 
     return;
-}
+  }
 
-//------------------------------------------------------------------------------------------------------------------------------------------
+  //------------------------------------------------------------------------------------------------------------------------------------------
 
-DEFINE_ART_CLASS_TOOL(SnippetHit3DBuilder)
+  DEFINE_ART_CLASS_TOOL(SnippetHit3DBuilder)
 } // namespace lar_cluster3d

--- a/larreco/RecoAlg/Cluster3DAlgs/SnippetHit3DBuilder_tool.cc
+++ b/larreco/RecoAlg/Cluster3DAlgs/SnippetHit3DBuilder_tool.cc
@@ -91,7 +91,7 @@ namespace lar_cluster3d {
      *  @brief Each algorithm may have different objects it wants "produced" so use this to
      *         let the top level producer module "know" what it is outputting
      */
-    virtual void produces(art::ProducesCollector&) override;
+    void produces(art::ProducesCollector&) override;
 
     void configure(const fhicl::ParameterSet&);
 
@@ -101,12 +101,12 @@ namespace lar_cluster3d {
      *  @param hitPairList           The input list of 3D hits to run clustering on
      *  @param clusterParametersList A list of cluster objects (parameters from associated hits)
      */
-    virtual void Hit3DBuilder(art::Event&, reco::HitPairList&, RecobHitToPtrMap&) override;
+    void Hit3DBuilder(art::Event&, reco::HitPairList&, RecobHitToPtrMap&) override;
 
     /**
      *  @brief If monitoring, recover the time to execute a particular function
      */
-    virtual float getTimeToExecute(IHit3DBuilder::TimeValues index) const override
+    float getTimeToExecute(IHit3DBuilder::TimeValues index) const override
     {
       return m_timeVector[index];
     }

--- a/larreco/RecoAlg/Cluster3DAlgs/SnippetHit3DBuilder_tool.cc
+++ b/larreco/RecoAlg/Cluster3DAlgs/SnippetHit3DBuilder_tool.cc
@@ -78,7 +78,7 @@ namespace lar_cluster3d {
   /**
  *  @brief  SnippetHit3DBuilder class definiton
  */
-  class SnippetHit3DBuilder : virtual public IHit3DBuilder {
+  class SnippetHit3DBuilder : public IHit3DBuilder {
   public:
     /**
      *  @brief  Constructor

--- a/larreco/RecoAlg/Cluster3DAlgs/SnippetHit3DBuilder_tool.cc
+++ b/larreco/RecoAlg/Cluster3DAlgs/SnippetHit3DBuilder_tool.cc
@@ -23,24 +23,24 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 // LArSoft includes
-#include "larcore/Geometry/Geometry.h"
 #include "larcore/Geometry/WireReadout.h"
+#include "larcore/Geometry/Geometry.h"
 #include "lardata/ArtDataHelper/HitCreator.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardataobj/RecoBase/Hit.h"
-#include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusService.h"
+#include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
 #include "larreco/RecoAlg/Cluster3DAlgs/IHit3DBuilder.h"
 
 // Eigen
 #include <Eigen/Core>
 
 // std includes
+#include <string>
 #include <iostream>
 #include <memory>
 #include <numeric> // std::accumulate
-#include <string>
 
 // Ack!
 #include "TH1F.h"
@@ -51,47 +51,51 @@
 
 namespace lar_cluster3d {
 
-  /**
-   *   @brief What follows are several highly useful typedefs which we
-   *          want to expose to the outside world
-   */
+/**
+ *   @brief What follows are several highly useful typedefs which we
+ *          want to expose to the outside world
+ */
 
-  // forward declaration to define an ordering function for our hit set
-  struct Hit2DSetCompare {
-    bool operator()(const reco::ClusterHit2D*, const reco::ClusterHit2D*) const;
-  };
+// forward declaration to define an ordering function for our hit set
+struct Hit2DSetCompare
+{
+    bool operator() (const reco::ClusterHit2D*, const reco::ClusterHit2D*) const;
+};
 
-  using HitVector = std::vector<const reco::ClusterHit2D*>;
-  using HitStartEndPair = std::pair<raw::TDCtick_t, raw::TDCtick_t>;
-  using SnippetHitMap = std::map<HitStartEndPair, HitVector>;
-  using PlaneToSnippetHitMap = std::map<geo::PlaneID, SnippetHitMap>;
-  using TPCToPlaneToSnippetHitMap = std::map<geo::TPCID, PlaneToSnippetHitMap>;
-  using Hit2DList = std::list<reco::ClusterHit2D>;
-  using Hit2DSet = std::set<const reco::ClusterHit2D*, Hit2DSetCompare>;
-  using WireToHitSetMap = std::map<unsigned int, Hit2DSet>;
-  using PlaneToWireToHitSetMap = std::map<geo::PlaneID, WireToHitSetMap>;
-  using TPCToPlaneToWireToHitSetMap = std::map<geo::TPCID, PlaneToWireToHitSetMap>;
-  using HitVectorMap = std::map<size_t, HitVector>;
-  using SnippetHitMapItrPair = std::pair<SnippetHitMap::iterator, SnippetHitMap::iterator>;
-  using PlaneSnippetHitMapItrPairVec = std::vector<SnippetHitMapItrPair>;
+using HitVector                    = std::vector<const reco::ClusterHit2D*>;
+using HitStartEndPair              = std::pair<raw::TDCtick_t,raw::TDCtick_t>;
+using SnippetHitMap                = std::map<HitStartEndPair,HitVector>;
+using PlaneToSnippetHitMap         = std::map<geo::PlaneID, SnippetHitMap>;
+using TPCToPlaneToSnippetHitMap    = std::map<geo::TPCID, PlaneToSnippetHitMap>;
+using Hit2DList                    = std::list<reco::ClusterHit2D>;
+using Hit2DSet                     = std::set<const reco::ClusterHit2D*, Hit2DSetCompare>;
+using WireToHitSetMap              = std::map<unsigned int, Hit2DSet>;
+using PlaneToWireToHitSetMap       = std::map<geo::PlaneID, WireToHitSetMap>;
+using TPCToPlaneToWireToHitSetMap  = std::map<geo::TPCID, PlaneToWireToHitSetMap>;
+using HitVectorMap                 = std::map<size_t, HitVector>;
+using SnippetHitMapItrPair         = std::pair<SnippetHitMap::iterator,SnippetHitMap::iterator>;
+using PlaneSnippetHitMapItrPairVec = std::vector<SnippetHitMapItrPair>;
 
-  /**
-   *  @brief  SnippetHit3DBuilder class definiton
-   */
-  class SnippetHit3DBuilder : public IHit3DBuilder {
-  public:
+/**
+ *  @brief  SnippetHit3DBuilder class definiton
+ */
+class SnippetHit3DBuilder : virtual public IHit3DBuilder
+{
+public:
     /**
      *  @brief  Constructor
      *
      *  @param  pset
      */
-    explicit SnippetHit3DBuilder(fhicl::ParameterSet const& pset);
+    explicit SnippetHit3DBuilder(fhicl::ParameterSet const &pset);
 
     /**
      *  @brief Each algorithm may have different objects it wants "produced" so use this to
      *         let the top level producer module "know" what it is outputting
      */
-    void produces(art::ProducesCollector&) override;
+    virtual void produces(art::ProducesCollector&) override;
+
+    void configure(const fhicl::ParameterSet&);
 
     /**
      *  @brief Given a set of recob hits, run DBscan to form 3D clusters
@@ -99,17 +103,15 @@ namespace lar_cluster3d {
      *  @param hitPairList           The input list of 3D hits to run clustering on
      *  @param clusterParametersList A list of cluster objects (parameters from associated hits)
      */
-    void Hit3DBuilder(art::Event&, reco::HitPairList&, RecobHitToPtrMap&) override;
+    virtual void Hit3DBuilder(art::Event&, reco::HitPairList&, RecobHitToPtrMap&) override;
 
     /**
      *  @brief If monitoring, recover the time to execute a particular function
      */
-    float getTimeToExecute(IHit3DBuilder::TimeValues index) const override
-    {
-      return m_timeVector[index];
-    }
+    virtual float getTimeToExecute(IHit3DBuilder::TimeValues index) const override {return m_timeVector[index];}
 
-  private:
+private:
+
     /**
      *  @brief  Extract the ART hits and the ART hit-particle relationships
      *
@@ -125,78 +127,77 @@ namespace lar_cluster3d {
     /**
      *  @brief Create a new 2D hit collection from hits associated to 3D space points
      */
-    void CreateNewRecobHitCollection(art::Event&,
-                                     reco::HitPairList&,
-                                     std::vector<recob::Hit>&,
-                                     RecobHitToPtrMap&);
+    void CreateNewRecobHitCollection(art::Event&, reco::HitPairList&, std::vector<recob::Hit>&, RecobHitToPtrMap&);
 
     /**
      *  @brief Create recob::Wire to recob::Hit associations
      */
-    void makeWireAssns(const art::Event&,
-                       art::Assns<recob::Wire, recob::Hit>&,
-                       RecobHitToPtrMap&) const;
+    void makeWireAssns(const art::Event&, art::Assns<recob::Wire, recob::Hit>&, RecobHitToPtrMap&) const;
 
     /**
      *  @brief Create raw::RawDigit to recob::Hit associations
      */
-    void makeRawDigitAssns(const art::Event&,
-                           art::Assns<raw::RawDigit, recob::Hit>&,
-                           RecobHitToPtrMap&) const;
+    void makeRawDigitAssns(const art::Event&, art::Assns<raw::RawDigit, recob::Hit>&, RecobHitToPtrMap&) const;
 
     /**
      *  @brief Given the ClusterHit2D objects, build the HitPairMap
      */
-    size_t BuildHitPairMap(PlaneToSnippetHitMap& planeToHitVectorMap,
-                           reco::HitPairList& hitPairList) const;
+    size_t BuildHitPairMap(PlaneToSnippetHitMap& planeToHitVectorMap, reco::HitPairList& hitPairList) const;
+
+    /**
+     * @brief This defines a structure allowing us to see which hits have already been matched. Generally, if two
+     *        hits have been matched then there is no point considering them anymore as it simply means duplicate
+     *        space points will be created
+     */
+    using MatchedHitMap = std::unordered_map<const reco::ClusterHit2D*,std::set<const reco::ClusterHit2D*>>;
 
     /**
      *  @brief Given the ClusterHit2D objects, build the HitPairMap
      */
-    size_t BuildHitPairMapByTPC(PlaneSnippetHitMapItrPairVec& planeSnippetHitMapItrPairVec,
-                                reco::HitPairList& hitPairList) const;
+    size_t BuildHitPairMapByTPC(PlaneSnippetHitMapItrPairVec& planeSnippetHitMapItrPairVec, reco::HitPairList& hitPairList) const;
 
     /**
      *  @brief This builds a list of candidate hit pairs from lists of hits on two planes
      */
-    using HitMatchTriplet =
-      std::tuple<const reco::ClusterHit2D*, const reco::ClusterHit2D*, const reco::ClusterHit3D>;
-    using HitMatchTripletVec = std::vector<HitMatchTriplet>;
-    using HitMatchTripletVecMap = std::map<geo::WireID, HitMatchTripletVec>;
+    using HitMatchTriplet       = std::tuple<const reco::ClusterHit2D*,const reco::ClusterHit2D*,const reco::ClusterHit3D>;
+    using HitMatchTripletVec    = std::vector<HitMatchTriplet>;
+    using HitMatchTripletVecMap = std::map<geo::WireID,HitMatchTripletVec>;
 
-    int findGoodHitPairs(SnippetHitMap::iterator&,
-                         SnippetHitMap::iterator&,
-                         SnippetHitMap::iterator&,
-                         HitMatchTripletVecMap&) const;
+    int findGoodHitPairs(SnippetHitMap::iterator&, SnippetHitMap::iterator&, SnippetHitMap::iterator&, HitMatchTripletVecMap&) const;
 
     /**
      *  @brief This algorithm takes lists of hit pairs and finds good triplets
      */
-    void findGoodTriplets(HitMatchTripletVecMap&, HitMatchTripletVecMap&, reco::HitPairList&) const;
+    void findGoodTriplets(HitMatchTripletVecMap&, HitMatchTripletVecMap&, MatchedHitMap&, reco::HitPairList&, bool = false) const;
+
+    /**
+     * @brief This will look at storing pair "orphans" where the 2D hits are otherwise unused
+     */
+
+    int saveOrphanPairs(HitMatchTripletVecMap&, MatchedHitMap&, reco::HitPairList&) const;
+
+    /**
+     * @brief This will look at storing pairs where the third channel is consistent with a "bad" channel
+     */
+
+    int saveBadChannelPairs(HitMatchTripletVecMap&, MatchedHitMap&, reco::HitPairList&) const;
 
     /**
      *  @brief Make a HitPair object by checking two hits
      */
-    bool makeHitPair(reco::ClusterHit3D& pairOut,
+    bool makeHitPair(reco::ClusterHit3D&       pairOut,
                      const reco::ClusterHit2D* hit1,
                      const reco::ClusterHit2D* hit2,
-                     float hitWidthSclFctr = 1.,
-                     size_t hitPairCntr = 0) const;
+                     float                     hitWidthSclFctr = 1.,
+                     size_t                    hitPairCntr = 0) const;
 
     /**
      *  @brief Make a 3D HitPair object by checking two hits
      */
-    bool makeHitTriplet(reco::ClusterHit3D& pairOut,
+    bool makeHitTriplet(reco::ClusterHit3D&       pairOut,
+                        MatchedHitMap&            matchedHitMap,
                         const reco::ClusterHit3D& pairIn,
                         const reco::ClusterHit2D* hit2) const;
-
-    /**
-     *  @brief Make a 3D HitPair object from a valid pair and a dead channel in the missing plane
-     */
-    bool makeDeadChannelPair(reco::ClusterHit3D& pairOut,
-                             const reco::ClusterHit3D& pair,
-                             size_t maxStatus,
-                             size_t minStatus) const;
 
     /**
      * @brief function to detemine if two wires "intersect" (in the 2D sense)
@@ -207,26 +208,17 @@ namespace lar_cluster3d {
     /**
      * @brief function to compute the distance of closest approach and the arc length to the points of closest approach
      */
-    float closestApproach(const Eigen::Vector3f&,
-                          const Eigen::Vector3f&,
-                          const Eigen::Vector3f&,
-                          const Eigen::Vector3f&,
-                          float&,
-                          float&) const;
+    float closestApproach(const Eigen::Vector3f&, const Eigen::Vector3f&, const Eigen::Vector3f&, const Eigen::Vector3f&, float&, float&) const;
 
     /**
      *  @brief A utility routine for finding a 2D hit closest in time to the given pair
      */
-    const reco::ClusterHit2D* FindBestMatchingHit(const Hit2DSet& hit2DSet,
-                                                  const reco::ClusterHit3D& pair,
-                                                  float pairDeltaTimeLimits) const;
+    const reco::ClusterHit2D* FindBestMatchingHit(const Hit2DSet& hit2DSet, const reco::ClusterHit3D& pair, float pairDeltaTimeLimits) const;
 
     /**
      *  @brief A utility routine for returning the number of 2D hits from the list in a given range
      */
-    int FindNumberInRange(const Hit2DSet& hit2DSet,
-                          const reco::ClusterHit3D& pair,
-                          float range) const;
+    int FindNumberInRange(const Hit2DSet& hit2DSet, const reco::ClusterHit3D& pair, float range) const;
 
     /**
      *  @brief Jacket the calls to finding the nearest wire in order to intercept the exceptions if out of range
@@ -236,24 +228,12 @@ namespace lar_cluster3d {
     /**
      *  @brief Jacket the calls to finding the nearest wire in order to intercept the exceptions if out of range
      */
-    float DistanceFromPointToHitWire(const Eigen::Vector3f& position,
-                                     const geo::WireID& wireID) const;
-
-    /**
-     *  @brief Create the internal channel status vector (assume will eventually be event-by-event)
-     */
-    void BuildChannelStatusVec() const;
+    float DistanceFromPointToHitWire(const Eigen::Vector3f& position, const geo::WireID& wireID) const;
 
     /**
      * @brief Perform charge integration between limits
      */
-    float chargeIntegral(float, float, float, int, int) const;
-
-    /**
-     *  @brief define data structure for keeping track of channel status
-     */
-    using ChannelStatusVec = std::vector<size_t>;
-    using ChannelStatusByPlaneVec = std::vector<ChannelStatusVec>;
+    float chargeIntegral(float,float,float,float,int,int) const;
 
     /**
      *  @brief clear the tuple vectors before processing next event
@@ -263,123 +243,194 @@ namespace lar_cluster3d {
     /**
      *  @brief Data members to follow
      */
-    std::vector<art::InputTag> m_hitFinderTagVec;
-    float m_hitWidthSclFctr;
-    float m_deltaPeakTimeSig;
-    float m_rangeNumSig;
-    float m_LongHitStretchFctr;
-    float m_pulseHeightFrac;
-    float m_PHLowSelection;
-    std::vector<int> m_invalidTPCVec;
-    float
-      m_wirePitchScaleFactor; ///< Scaling factor to determine max distance allowed between candidate pairs
-    float m_maxHit3DChiSquare; ///< Provide ability to select hits based on "chi square"
-    bool m_outputHistograms;   ///< Take the time to create and fill some histograms for diagnostics
+    using TickCorrectionArray = std::vector<std::vector<std::vector<float>>>;
 
-    bool m_enableMonitoring; ///<
-    float m_wirePitch[3];
-    mutable std::vector<float> m_timeVector; ///<
+    std::vector<art::InputTag>              m_hitFinderTagVec;
+    float                                   m_hitWidthSclFctr;
+    float                                   m_deltaPeakTimeSig;
+    float                                   m_rangeNumSig;
+    float                                   m_LongHitStretchFctr;
+    float                                   m_pulseHeightFrac;
+    float                                   m_PHLowSelection;
+    float                                   m_minPHFor2HitPoints;    ///< Set a minimum pulse height for 2 hit space point candidates
+    std::vector<int>                        m_invalidTPCVec;
+    float                                   m_wirePitchScaleFactor;  ///< Scaling factor to determine max distance allowed between candidate pairs
+    float                                   m_maxHit3DChiSquare;     ///< Provide ability to select hits based on "chi square"
+    bool                                    m_saveBadChannelPairs;   ///< Should we save pairs consistent with bad channels?
+    bool                                    m_saveMythicalPoints;    ///< Should we save valid 2 hit space points? 
+    float                                   m_maxMythicalChiSquare;  ///< Selection cut on mythical points
+    bool                                    m_useT0Offsets;          ///< If true then we will use the LArSoft interplane offsets
+    bool                                    m_outputHistograms;      ///< Take the time to create and fill some histograms for diagnostics
+    bool                                    m_makeAssociations;      ///< Do we make wire/rawdigit associations to space points?
 
-    float m_zPosOffset;
+    bool                                    m_enableMonitoring;      ///<
+    float                                   m_wirePitch[3];
+    mutable std::vector<float>              m_timeVector;            ///<
 
-    // Define some basic histograms
-    TTree* m_tupleTree; ///< output analysis tree
+    float                                   m_zPosOffset;
 
-    mutable std::vector<float> m_deltaTimeVec;
-    mutable std::vector<float> m_chiSquare3DVec;
-    mutable std::vector<float> m_maxPullVec;
-    mutable std::vector<float> m_overlapFractionVec;
-    mutable std::vector<float> m_overlapRangeVec;
-    mutable std::vector<float> m_maxDeltaPeakVec;
-    mutable std::vector<float> m_maxSideVecVec;
-    mutable std::vector<float> m_pairWireDistVec;
-    mutable std::vector<float> m_smallChargeDiffVec;
-    mutable std::vector<int> m_smallIndexVec;
-    mutable std::vector<float> m_qualityMetricVec;
-    mutable std::vector<float> m_spacePointChargeVec;
-    mutable std::vector<float> m_hitAsymmetryVec;
+    using PlaneToT0OffsetMap = std::map<geo::PlaneID,float>;
+
+    PlaneToT0OffsetMap                      m_PlaneToT0OffsetMap;
+
+    // Define some basic histograms   
+    TTree*                                  m_tupleTree;             ///< output analysis tree
+
+    mutable std::vector<float>              m_deltaPeakTimePlane0Vec;
+    mutable std::vector<float>              m_deltaPeakSigmaPlane0Vec;
+    mutable std::vector<float>              m_deltaPeakTimePlane1Vec;
+    mutable std::vector<float>              m_deltaPeakSigmaPlane1Vec;
+    mutable std::vector<float>              m_deltaPeakTimePlane2Vec;
+    mutable std::vector<float>              m_deltaPeakSigmaPlane2Vec;
+
+    mutable std::vector<float>              m_deltaTimeVec;
+    mutable std::vector<float>              m_deltaTime0Vec;
+    mutable std::vector<float>              m_deltaSigma0Vec;
+    mutable std::vector<float>              m_deltaTime1Vec;
+    mutable std::vector<float>              m_deltaSigma1Vec;
+    mutable std::vector<float>              m_deltaTime2Vec;
+    mutable std::vector<float>              m_deltaSigma2Vec;
+    mutable std::vector<float>              m_chiSquare3DVec;
+    mutable std::vector<float>              m_maxPullVec;
+    mutable std::vector<float>              m_overlapFractionVec;
+    mutable std::vector<float>              m_overlapRangeVec;
+    mutable std::vector<float>              m_maxDeltaPeakVec;
+    mutable std::vector<float>              m_maxSideVecVec;
+    mutable std::vector<float>              m_pairWireDistVec;
+    mutable std::vector<float>              m_smallChargeDiffVec;
+    mutable std::vector<int>                m_smallIndexVec;
+    mutable std::vector<float>              m_qualityMetricVec;
+    mutable std::vector<float>              m_spacePointChargeVec;
+    mutable std::vector<float>              m_hitAsymmetryVec;
+    mutable std::vector<float>              m_2hit1stPHVec;
+    mutable std::vector<float>              m_2hit2ndPHVec;
+    mutable std::vector<float>              m_2hitDeltaPHVec;
+    mutable std::vector<float>              m_2hitSumPHVec;
 
     // Get instances of the primary data structures needed
-    mutable Hit2DList m_clusterHit2DMasterList;
-    mutable PlaneToSnippetHitMap m_planeToSnippetHitMap;
-    mutable PlaneToWireToHitSetMap m_planeToWireToHitSetMap;
+    mutable Hit2DList                       m_clusterHit2DMasterList;
+    mutable PlaneToSnippetHitMap            m_planeToSnippetHitMap;
+    mutable PlaneToWireToHitSetMap          m_planeToWireToHitSetMap;
 
-    mutable ChannelStatusByPlaneVec m_channelStatus;
-    mutable size_t m_numBadChannels;
+    mutable bool                            m_weHaveAllBeenHereBefore = false;
 
-    mutable bool m_weHaveAllBeenHereBefore = false;
+    const geo::Geometry*                    m_geometry;              //< pointer to the Geometry service
+    const geo::WireReadoutGeom*             m_wireReadoutAlg;        //< The new wire readout service
+    const lariov::ChannelStatusProvider*    m_channelFilter;
+};
 
-    const geo::Geometry* m_geometry; //< pointer to the Geometry service
-    const geo::WireReadoutGeom* m_wireReadoutGeom;
-    const lariov::ChannelStatusProvider* m_channelFilter;
-  };
+SnippetHit3DBuilder::SnippetHit3DBuilder(fhicl::ParameterSet const &pset) :
+    m_channelFilter(&art::ServiceHandle<lariov::ChannelStatusService const>()->GetProvider())
 
-  SnippetHit3DBuilder::SnippetHit3DBuilder(fhicl::ParameterSet const& pset)
-    : m_channelFilter(&art::ServiceHandle<lariov::ChannelStatusService const>()->GetProvider())
-  {
-    m_hitFinderTagVec = pset.get<std::vector<art::InputTag>>(
-      "HitFinderTagVec", std::vector<art::InputTag>() = {"gaushit"});
-    m_enableMonitoring = pset.get<bool>("EnableMonitoring", true);
-    m_hitWidthSclFctr = pset.get<float>("HitWidthScaleFactor", 6.);
-    m_rangeNumSig = pset.get<float>("RangeNumSigma", 3.);
-    m_LongHitStretchFctr = pset.get<float>("LongHitsStretchFactor", 1.5);
-    m_pulseHeightFrac = pset.get<float>("PulseHeightFraction", 0.5);
-    m_PHLowSelection = pset.get<float>("PHLowSelection", 20.);
-    m_deltaPeakTimeSig = pset.get<float>("DeltaPeakTimeSig", 1.7);
-    m_zPosOffset = pset.get<float>("ZPosOffset", 0.0);
-    m_invalidTPCVec = pset.get<std::vector<int>>("InvalidTPCVec", std::vector<int>());
-    m_wirePitchScaleFactor = pset.get<float>("WirePitchScaleFactor", 1.9);
-    m_maxHit3DChiSquare = pset.get<float>("MaxHitChiSquare", 6.0);
-    m_outputHistograms = pset.get<bool>("OutputHistograms", false);
+{
+    this->configure(pset);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void SnippetHit3DBuilder::produces(art::ProducesCollector& collector)
+{
+    collector.produces< std::vector<recob::Hit>>();
+    collector.produces< art::Assns<recob::Wire,   recob::Hit>>();
+    collector.produces< art::Assns<raw::RawDigit, recob::Hit>>();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void SnippetHit3DBuilder::configure(fhicl::ParameterSet const &pset)
+{
+    m_hitFinderTagVec      = pset.get<std::vector<art::InputTag>>("HitFinderTagVec",        {"gaushit"});
+    m_enableMonitoring     = pset.get<bool                      >("EnableMonitoring",       true);
+    m_hitWidthSclFctr      = pset.get<float                     >("HitWidthScaleFactor",    6.  );
+    m_rangeNumSig          = pset.get<float                     >("RangeNumSigma",          3.  );
+    m_LongHitStretchFctr   = pset.get<float                     >("LongHitsStretchFactor",  1.5 );
+    m_pulseHeightFrac      = pset.get<float                     >("PulseHeightFraction",    0.5 );
+    m_PHLowSelection       = pset.get<float                     >("PHLowSelection",         20. );
+    m_minPHFor2HitPoints   = pset.get<float                     >("MinPHFor2HitPoints",     15. );
+    m_deltaPeakTimeSig     = pset.get<float                     >("DeltaPeakTimeSig",       1.7 );
+    m_zPosOffset           = pset.get<float                     >("ZPosOffset",             0.0 );
+    m_invalidTPCVec        = pset.get<std::vector<int>          >("InvalidTPCVec",          std::vector<int>());
+    m_wirePitchScaleFactor = pset.get<float                     >("WirePitchScaleFactor",   1.9 );
+    m_maxHit3DChiSquare    = pset.get<float                     >("MaxHitChiSquare",        6.0 );
+    m_saveBadChannelPairs  = pset.get<bool                      >("SaveBadChannelPairs",    true);
+    m_saveMythicalPoints   = pset.get<bool                      >("SaveMythicalPoints",     true);
+    m_maxMythicalChiSquare = pset.get<float                     >("MaxMythicalChiSquare",    10.);
+    m_useT0Offsets         = pset.get<bool                      >("UseT0Offsets",           true);
+    m_outputHistograms     = pset.get<bool                      >("OutputHistograms",      false);
+    m_makeAssociations     = pset.get<bool                      >("MakeAssociations",      false);
 
     m_geometry = art::ServiceHandle<geo::Geometry const>{}.get();
-    m_wireReadoutGeom = &art::ServiceHandle<geo::WireReadout const>()->Get();
+    m_wireReadoutAlg = &art::ServiceHandle<geo::WireReadout const>{}->Get();
 
     // Returns the wire pitch per plane assuming they will be the same for all TPCs
     constexpr geo::TPCID tpcid{0, 0};
-    m_wirePitch[0] = m_wireReadoutGeom->Plane(geo::PlaneID{tpcid, 0}).WirePitch();
-    m_wirePitch[1] = m_wireReadoutGeom->Plane(geo::PlaneID{tpcid, 1}).WirePitch();
-    m_wirePitch[2] = m_wireReadoutGeom->Plane(geo::PlaneID{tpcid, 2}).WirePitch();
+    m_wirePitch[0] = m_wireReadoutAlg->Plane(geo::PlaneID{tpcid, 0}).WirePitch();
+    m_wirePitch[1] = m_wireReadoutAlg->Plane(geo::PlaneID{tpcid, 1}).WirePitch();
+    m_wirePitch[2] = m_wireReadoutAlg->Plane(geo::PlaneID{tpcid, 2}).WirePitch();
 
     // Access ART's TFileService, which will handle creating and writing
     // histograms and n-tuples for us.
-    if (m_outputHistograms) {
-      art::ServiceHandle<art::TFileService> tfs;
+    if (m_outputHistograms)
+    {
+        art::ServiceHandle<art::TFileService> tfs;
 
-      m_tupleTree = tfs->make<TTree>("Hit3DBuilderTree", "Tree by SnippetHit3DBuilder");
+        m_tupleTree = tfs->make<TTree>("Hit3DBuilderTree", "Tree by SnippetHit3DBuilder");
 
-      clear();
+        clear();
 
-      m_tupleTree->Branch("DeltaTime2D", "std::vector<float>", &m_deltaTimeVec);
-      m_tupleTree->Branch("ChiSquare3D", "std::vector<float>", &m_chiSquare3DVec);
-      m_tupleTree->Branch("MaxPullValue", "std::vector<float>", &m_maxPullVec);
-      m_tupleTree->Branch("OverlapFraction", "std::vector<float>", &m_overlapFractionVec);
-      m_tupleTree->Branch("OverlapRange", "std::vector<float>", &m_overlapRangeVec);
-      m_tupleTree->Branch("MaxDeltaPeak", "std::vector<float>", &m_maxDeltaPeakVec);
-      m_tupleTree->Branch("MaxSideVec", "std::vector<float>", &m_maxSideVecVec);
-      m_tupleTree->Branch("PairWireDistVec", "std::vector<float>", &m_pairWireDistVec);
-      m_tupleTree->Branch("SmallChargeDiff", "std::vector<float>", &m_smallChargeDiffVec);
-      m_tupleTree->Branch("SmallChargeIdx", "std::vector<int>", &m_smallIndexVec);
-      m_tupleTree->Branch("QualityMetric", "std::vector<float>", &m_qualityMetricVec);
-      m_tupleTree->Branch("SPCharge", "std::vector<float>", &m_spacePointChargeVec);
-      m_tupleTree->Branch("HitAsymmetry", "std::vector<float>", &m_hitAsymmetryVec);
+        m_tupleTree->Branch("DeltaPeakTimePair0",  "std::vector<float>", &m_deltaPeakTimePlane0Vec);
+        m_tupleTree->Branch("DeltaPeakSigmaPair0", "std::vector<float>", &m_deltaPeakSigmaPlane0Vec);
+        m_tupleTree->Branch("DeltaPeakTimePair1",  "std::vector<float>", &m_deltaPeakTimePlane1Vec);
+        m_tupleTree->Branch("DeltaPeakSigmaPair1", "std::vector<float>", &m_deltaPeakSigmaPlane1Vec);
+        m_tupleTree->Branch("DeltaPeakTimePair2",  "std::vector<float>", &m_deltaPeakTimePlane2Vec);
+        m_tupleTree->Branch("DeltaPeakSigmaPair2", "std::vector<float>", &m_deltaPeakSigmaPlane2Vec);
+
+        m_tupleTree->Branch("DeltaTime2D",     "std::vector<float>", &m_deltaTimeVec);
+        m_tupleTree->Branch("DeltaTime2D0",    "std::vector<float>", &m_deltaTime0Vec);
+        m_tupleTree->Branch("DeltaSigma2D0",   "std::vector<float>", &m_deltaSigma0Vec);
+        m_tupleTree->Branch("DeltaTime2D1",    "std::vector<float>", &m_deltaTime1Vec);
+        m_tupleTree->Branch("DeltaSigma2D1",   "std::vector<float>", &m_deltaSigma1Vec);
+        m_tupleTree->Branch("DeltaTime2D2",    "std::vector<float>", &m_deltaTime2Vec);
+        m_tupleTree->Branch("DeltaSigma2D2",   "std::vector<float>", &m_deltaSigma2Vec);
+        m_tupleTree->Branch("ChiSquare3D",     "std::vector<float>", &m_chiSquare3DVec);
+        m_tupleTree->Branch("MaxPullValue",    "std::vector<float>", &m_maxPullVec);
+        m_tupleTree->Branch("OverlapFraction", "std::vector<float>", &m_overlapFractionVec);
+        m_tupleTree->Branch("OverlapRange",    "std::vector<float>", &m_overlapRangeVec);
+        m_tupleTree->Branch("MaxDeltaPeak",    "std::vector<float>", &m_maxDeltaPeakVec);
+        m_tupleTree->Branch("MaxSideVec",      "std::vector<float>", &m_maxSideVecVec);
+        m_tupleTree->Branch("PairWireDistVec", "std::vector<float>", &m_pairWireDistVec);
+        m_tupleTree->Branch("SmallChargeDiff", "std::vector<float>", &m_smallChargeDiffVec);
+        m_tupleTree->Branch("SmallChargeIdx",  "std::vector<int>",   &m_smallIndexVec);
+        m_tupleTree->Branch("QualityMetric",   "std::vector<float>", &m_qualityMetricVec);
+        m_tupleTree->Branch("SPCharge",        "std::vector<float>", &m_spacePointChargeVec);
+        m_tupleTree->Branch("HitAsymmetry",    "std::vector<float>", &m_hitAsymmetryVec);
+
+        m_tupleTree->Branch("2hit1stPH",       "std::vector<float>", &m_2hit1stPHVec);
+        m_tupleTree->Branch("2hit2ndPH",       "std::vector<float>", &m_2hit2ndPHVec);
+        m_tupleTree->Branch("2hitDeltaPH",     "std::vector<float>", &m_2hitDeltaPHVec);
+        m_tupleTree->Branch("2hitSumPH",       "std::vector<float>", &m_2hitSumPHVec);
+
     }
-  }
 
-  //------------------------------------------------------------------------------------------------------------------------------------------
+    return;
+}
 
-  void SnippetHit3DBuilder::produces(art::ProducesCollector& collector)
-  {
-    collector.produces<std::vector<recob::Hit>>();
-    collector.produces<art::Assns<recob::Wire, recob::Hit>>();
-    collector.produces<art::Assns<raw::RawDigit, recob::Hit>>();
-  }
+void SnippetHit3DBuilder::clear()
+{
+    m_deltaPeakTimePlane0Vec.clear();
+    m_deltaPeakSigmaPlane0Vec.clear();
+    m_deltaPeakTimePlane1Vec.clear();
+    m_deltaPeakSigmaPlane1Vec.clear();
+    m_deltaPeakTimePlane1Vec.clear();
+    m_deltaPeakSigmaPlane1Vec.clear();
 
-  //------------------------------------------------------------------------------------------------------------------------------------------
-
-  void SnippetHit3DBuilder::clear()
-  {
     m_deltaTimeVec.clear();
+    m_deltaTime0Vec.clear();
+    m_deltaSigma0Vec.clear();
+    m_deltaTime1Vec.clear();
+    m_deltaSigma1Vec.clear();
+    m_deltaTime2Vec.clear();
+    m_deltaSigma2Vec.clear();
     m_chiSquare3DVec.clear();
     m_maxPullVec.clear();
     m_overlapFractionVec.clear();
@@ -392,61 +443,63 @@ namespace lar_cluster3d {
     m_qualityMetricVec.clear();
     m_spacePointChargeVec.clear();
     m_hitAsymmetryVec.clear();
-  }
 
-  void SnippetHit3DBuilder::BuildChannelStatusVec() const
-  {
-    // This is called each event, clear out the previous version and start over
-    m_channelStatus.clear();
+    m_2hit1stPHVec.clear();
+    m_2hit2ndPHVec.clear();
+    m_2hitDeltaPHVec.clear();
+    m_2hitSumPHVec.clear();
 
-    m_numBadChannels = 0;
-    m_channelStatus.resize(m_wireReadoutGeom->Nplanes());
+    return;
+}
 
-    // Loop through views/planes to set the wire length vectors
-    constexpr geo::TPCID tpcid{0, 0};
-    for (unsigned int idx = 0; idx < m_channelStatus.size(); idx++) {
-      m_channelStatus[idx] =
-        ChannelStatusVec(m_wireReadoutGeom->Nwires(geo::PlaneID{tpcid, idx}), 5);
-    }
-
-    // Loop through the channels and mark those that are "bad"
-    for (size_t channel = 0; channel < m_wireReadoutGeom->Nchannels(); channel++) {
-      if (m_channelFilter->IsGood(channel)) continue;
-
-      std::vector<geo::WireID> wireIDVec = m_wireReadoutGeom->ChannelToWire(channel);
-      geo::WireID wireID = wireIDVec[0];
-      lariov::ChannelStatusProvider::Status_t chanStat = m_channelFilter->Status(channel);
-
-      m_channelStatus[wireID.Plane][wireID.Wire] = chanStat;
-      ++m_numBadChannels;
-    }
-  }
-
-  bool SetPeakHitPairIteratorOrder(const reco::HitPairList::iterator& left,
-                                   const reco::HitPairList::iterator& right)
-  {
+bool SetPeakHitPairIteratorOrder(const reco::HitPairList::iterator& left, const reco::HitPairList::iterator& right)
+{
     return (*left).getAvePeakTime() < (*right).getAvePeakTime();
-  }
+}
 
-  struct HitPairClusterOrder {
-    bool operator()(const reco::HitPairClusterMap::iterator& left,
-                    const reco::HitPairClusterMap::iterator& right)
+struct HitPairClusterOrder
+{
+    bool operator()(const reco::HitPairClusterMap::iterator& left, const reco::HitPairClusterMap::iterator& right)
     {
-      // Watch out for the case where two clusters can have the same number of hits!
-      if (left->second.size() == right->second.size()) return left->first < right->first;
+        // Watch out for the case where two clusters can have the same number of hits!
+        if (left->second.size() == right->second.size())
+            return left->first < right->first;
 
-      return left->second.size() > right->second.size();
+        return left->second.size() > right->second.size();
     }
-  };
+};
 
-  void SnippetHit3DBuilder::Hit3DBuilder(art::Event& evt,
-                                         reco::HitPairList& hitPairList,
-                                         RecobHitToPtrMap& clusterHitToArtPtrMap)
-  {
+void SnippetHit3DBuilder::Hit3DBuilder(art::Event& evt, reco::HitPairList& hitPairList, RecobHitToPtrMap& clusterHitToArtPtrMap)
+{
     // Clear the internal data structures
     m_clusterHit2DMasterList.clear();
     m_planeToSnippetHitMap.clear();
     m_planeToWireToHitSetMap.clear();
+
+    mf::LogDebug("SnippetHit3D") << "SnippetHit3DBuilder entered" << std::endl;
+
+    // Do the one time initialization of the tick offsets.
+    if (m_PlaneToT0OffsetMap.empty())
+    {
+        // Need the detector properties which needs the clocks
+        auto const clock_data = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+        auto const det_prop   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clock_data);
+
+        // Initialize the plane to hit vector map
+        for(size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++)
+        {
+            for(size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++)
+            {
+                for(size_t planeIdx = 0; planeIdx < m_wireReadoutAlg->Nplanes(); planeIdx++)
+                {
+                    geo::PlaneID planeID(cryoIdx,tpcIdx,planeIdx);
+
+                    if (m_useT0Offsets) m_PlaneToT0OffsetMap[planeID] = det_prop.GetXTicksOffset(planeID) - det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,0));
+                    else                m_PlaneToT0OffsetMap[planeID] = 0.;
+                }
+            }
+        }
+    }
 
     m_timeVector.resize(NUMTIMEVALUES, 0.);
 
@@ -455,30 +508,31 @@ namespace lar_cluster3d {
 
     // Recover the 2D hits and then organize them into data structures which will be used in the
     // DBscan algorithm for building the 3D clusters
-    CollectArtHits(evt);
+    this->CollectArtHits(evt);
+
+    mf::LogDebug("SnippetHit3D") << "SnippetHit3DBuilder building space points";
 
     // If there are no hits in our view/wire data structure then do not proceed with the full analysis
-    if (!m_planeToWireToHitSetMap.empty()) {
-      // Call the algorithm that builds 3D hits
-      BuildHit3D(hitPairList);
+    if (!m_planeToWireToHitSetMap.empty())
+    {
+        // Call the algorithm that builds 3D hits
+        this->BuildHit3D(hitPairList);
 
-      // If we built 3D points then attempt to output a new hit list as well
-      if (!hitPairList.empty())
-        CreateNewRecobHitCollection(evt, hitPairList, *outputHitPtrVec, clusterHitToArtPtrMap);
+        // If we built 3D points then attempt to output a new hit list as well
+        if (!hitPairList.empty())
+            CreateNewRecobHitCollection(evt, hitPairList, *outputHitPtrVec, clusterHitToArtPtrMap);
     }
 
     // Set up to make the associations (if desired)
     /// Associations with wires.
-    std::unique_ptr<art::Assns<recob::Wire, recob::Hit>> wireAssns(
-      new art::Assns<recob::Wire, recob::Hit>);
+    std::unique_ptr<art::Assns<recob::Wire, recob::Hit>> wireAssns(new art::Assns<recob::Wire, recob::Hit>);
 
-    makeWireAssns(evt, *wireAssns, clusterHitToArtPtrMap);
+    if (m_makeAssociations) makeWireAssns(evt, *wireAssns, clusterHitToArtPtrMap);
 
     /// Associations with raw digits.
-    std::unique_ptr<art::Assns<raw::RawDigit, recob::Hit>> rawDigitAssns(
-      new art::Assns<raw::RawDigit, recob::Hit>);
+    std::unique_ptr<art::Assns<raw::RawDigit, recob::Hit>> rawDigitAssns(new art::Assns<raw::RawDigit, recob::Hit>);
 
-    makeRawDigitAssns(evt, *rawDigitAssns, clusterHitToArtPtrMap);
+    if (m_makeAssociations) makeRawDigitAssns(evt, *rawDigitAssns, clusterHitToArtPtrMap);
 
     // Move everything into the event
     evt.put(std::move(outputHitPtrVec));
@@ -486,15 +540,20 @@ namespace lar_cluster3d {
     evt.put(std::move(rawDigitAssns));
 
     // Handle tree output too
-    if (m_outputHistograms) {
-      m_tupleTree->Fill();
+    if (m_outputHistograms)
+    {
+        m_tupleTree->Fill();
 
-      clear();
+        clear();
     }
-  }
 
-  void SnippetHit3DBuilder::BuildHit3D(reco::HitPairList& hitPairList) const
-  {
+    mf::LogDebug("SnippetHit3D") << "SnippetHit3DBuilder exited";
+
+    return;
+}
+
+void SnippetHit3DBuilder::BuildHit3D(reco::HitPairList& hitPairList) const
+{
     /**
      *  @brief Driver for processing input 2D hits, transforming to 3D hits and building lists
      *         of associated 3D hits (candidate 3D clusters)
@@ -503,47 +562,50 @@ namespace lar_cluster3d {
 
     if (m_enableMonitoring) theClockMakeHits.start();
 
-    // The first task is to take the lists of input 2D hits (a map of view to sorted lists of 2D hits)
-    // and then to build a list of 3D hits to be used in downstream processing
-    BuildChannelStatusVec();
-
     size_t numHitPairs = BuildHitPairMap(m_planeToSnippetHitMap, hitPairList);
 
-    if (m_enableMonitoring) {
-      theClockMakeHits.stop();
+    if (m_enableMonitoring)
+    {
+        theClockMakeHits.stop();
 
-      m_timeVector[BUILDTHREEDHITS] = theClockMakeHits.accumulated_real_time();
+        m_timeVector[BUILDTHREEDHITS] = theClockMakeHits.accumulated_real_time();
     }
 
-    mf::LogDebug("Cluster3D") << ">>>>> 3D hit building done, found " << numHitPairs << " 3D Hits"
-                              << std::endl;
-  }
+    mf::LogDebug("SnippetHit3D") << ">>>>> 3D hit building done, found " << numHitPairs << " 3D Hits" << std::endl;
 
-  //------------------------------------------------------------------------------------------------------------------------------------------
-  struct SetStartTimeOrder {
+    return;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+class SetStartTimeOrder
+{
+public:
+    SetStartTimeOrder() {}
+
     bool operator()(const SnippetHitMapItrPair& left, const SnippetHitMapItrPair& right) const
     {
-      // Special case handling, there is nothing to compare for the left or right
-      if (left.first == left.second) return false;
-      if (right.first == right.second) return true;
+        // Special case handling, there is nothing to compare for the left or right
+        if (left.first  == left.second)  return false;
+        if (right.first == right.second) return true;
 
-      // de-referencing a bunch of pairs here...
-      return left.first->first.first < right.first->first.first;
+        // de-referencing a bunch of pairs here...
+        return left.first->first.first < right.first->first.first;
     }
-  };
 
-  bool SetPairStartTimeOrder(const reco::ClusterHit3D& left, const reco::ClusterHit3D& right)
-  {
+private:
+};
+
+bool SetPairStartTimeOrder(const reco::ClusterHit3D& left, const reco::ClusterHit3D& right)
+{
     // Sort by "modified start time" of pulse
-    return left.getAvePeakTime() - left.getSigmaPeakTime() <
-           right.getAvePeakTime() - right.getSigmaPeakTime();
-  }
+    return left.getAvePeakTime() - left.getSigmaPeakTime() < right.getAvePeakTime() - right.getSigmaPeakTime();
+}
 
-  //------------------------------------------------------------------------------------------------------------------------------------------
 
-  size_t SnippetHit3DBuilder::BuildHitPairMap(PlaneToSnippetHitMap& planeToSnippetHitMap,
-                                              reco::HitPairList& hitPairList) const
-  {
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+size_t SnippetHit3DBuilder::BuildHitPairMap(PlaneToSnippetHitMap& planeToSnippetHitMap, reco::HitPairList& hitPairList) const
+{
     /**
      *  @brief Given input 2D hits, build out the lists of possible 3D hits
      *
@@ -557,55 +619,51 @@ namespace lar_cluster3d {
     size_t hitPairCntr(0);
 
     size_t nTriplets(0);
-    size_t nDeadChanHits(0);
 
     // Set up to loop over cryostats and tpcs...
-    for (size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++) {
-      for (size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++) {
-        PlaneToSnippetHitMap::iterator mapItr0 =
-          planeToSnippetHitMap.find(geo::PlaneID(cryoIdx, tpcIdx, 0));
-        PlaneToSnippetHitMap::iterator mapItr1 =
-          planeToSnippetHitMap.find(geo::PlaneID(cryoIdx, tpcIdx, 1));
-        PlaneToSnippetHitMap::iterator mapItr2 =
-          planeToSnippetHitMap.find(geo::PlaneID(cryoIdx, tpcIdx, 2));
+    for(size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++)
+    {
+        for(size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++)
+        {
+            //************************************
+            // Kludge
+//            if (!(cryoIdx == 1 && tpcIdx == 0)) continue;
 
-        size_t nPlanesWithHits =
-          (mapItr0 != planeToSnippetHitMap.end() && !mapItr0->second.empty() ? 1 : 0) +
-          (mapItr1 != planeToSnippetHitMap.end() && !mapItr1->second.empty() ? 1 : 0) +
-          (mapItr2 != planeToSnippetHitMap.end() && !mapItr2->second.empty() ? 1 : 0);
+            PlaneToSnippetHitMap::iterator mapItr0 = planeToSnippetHitMap.find(geo::PlaneID(cryoIdx,tpcIdx,0));
+            PlaneToSnippetHitMap::iterator mapItr1 = planeToSnippetHitMap.find(geo::PlaneID(cryoIdx,tpcIdx,1));
+            PlaneToSnippetHitMap::iterator mapItr2 = planeToSnippetHitMap.find(geo::PlaneID(cryoIdx,tpcIdx,2));
 
-        if (nPlanesWithHits < 2) continue;
+            size_t nPlanesWithHits = (mapItr0 != planeToSnippetHitMap.end() && !mapItr0->second.empty() ? 1 : 0)
+                                   + (mapItr1 != planeToSnippetHitMap.end() && !mapItr1->second.empty() ? 1 : 0)
+                                   + (mapItr2 != planeToSnippetHitMap.end() && !mapItr2->second.empty() ? 1 : 0);
 
-        SnippetHitMap& snippetHitMap0 = mapItr0->second;
-        SnippetHitMap& snippetHitMap1 = mapItr1->second;
-        SnippetHitMap& snippetHitMap2 = mapItr2->second;
+            if (nPlanesWithHits < 2) continue;
 
-        PlaneSnippetHitMapItrPairVec hitItrVec = {
-          SnippetHitMapItrPair(snippetHitMap0.begin(), snippetHitMap0.end()),
-          SnippetHitMapItrPair(snippetHitMap1.begin(), snippetHitMap1.end()),
-          SnippetHitMapItrPair(snippetHitMap2.begin(), snippetHitMap2.end())};
+            SnippetHitMap& snippetHitMap0 = mapItr0->second;
+            SnippetHitMap& snippetHitMap1 = mapItr1->second;
+            SnippetHitMap& snippetHitMap2 = mapItr2->second;
 
-        totalNumHits += BuildHitPairMapByTPC(hitItrVec, hitPairList);
-      }
+            PlaneSnippetHitMapItrPairVec hitItrVec = {SnippetHitMapItrPair(snippetHitMap0.begin(),snippetHitMap0.end()),
+                                                      SnippetHitMapItrPair(snippetHitMap1.begin(),snippetHitMap1.end()),
+                                                      SnippetHitMapItrPair(snippetHitMap2.begin(),snippetHitMap2.end())};
+
+            totalNumHits += BuildHitPairMapByTPC(hitItrVec, hitPairList);
+        }
     }
 
     // Return the hit pair list but sorted by z and y positions (faster traversal in next steps)
     hitPairList.sort(SetPairStartTimeOrder);
 
     // Where are we?
-    mf::LogDebug("Cluster3D") << "Total number hits: " << totalNumHits << std::endl;
-    mf::LogDebug("Cluster3D") << "Created a total of " << hitPairList.size()
-                              << " hit pairs, counted: " << hitPairCntr << std::endl;
-    mf::LogDebug("Cluster3D") << "-- Triplets: " << nTriplets
-                              << ", dead channel pairs: " << nDeadChanHits << std::endl;
+    mf::LogDebug("SnippetHit3D") << "Total number hits: " << totalNumHits << std::endl;
+    mf::LogDebug("SnippetHit3D") << "Created a total of " << hitPairList.size() << " hit pairs, counted: " << hitPairCntr << std::endl;
+    mf::LogDebug("SnippetHit3D") << "-- Triplets: " << nTriplets << std::endl;
 
     return hitPairList.size();
-  }
+}
 
-  size_t SnippetHit3DBuilder::BuildHitPairMapByTPC(
-    PlaneSnippetHitMapItrPairVec& snippetHitMapItrVec,
-    reco::HitPairList& hitPairList) const
-  {
+size_t SnippetHit3DBuilder::BuildHitPairMapByTPC(PlaneSnippetHitMapItrPairVec& snippetHitMapItrVec, reco::HitPairList& hitPairList) const
+{
     /**
      *  @brief Given input 2D hits, build out the lists of possible 3D hits
      *
@@ -617,289 +675,382 @@ namespace lar_cluster3d {
      */
 
     // Define functions to set start/end iterators in the loop below
-    auto SetStartIterator =
-      [](SnippetHitMap::iterator startItr, SnippetHitMap::iterator endItr, float startTime) {
-        while (startItr != endItr) {
-          if (startItr->first.second < startTime)
-            startItr++;
-          else
-            break;
+    auto SetStartIterator = [](SnippetHitMap::iterator startItr, SnippetHitMap::iterator endItr, float startTime)
+    {
+        while(startItr != endItr)
+        {
+            if (startItr->first.second < startTime) startItr++;
+            else break;
         }
         return startItr;
-      };
+    };
 
-    auto SetEndIterator =
-      [](SnippetHitMap::iterator lastItr, SnippetHitMap::iterator endItr, float endTime) {
-        while (lastItr != endItr) {
-          if (lastItr->first.first < endTime)
-            lastItr++;
-          else
-            break;
+    auto SetEndIterator = [](SnippetHitMap::iterator lastItr, SnippetHitMap::iterator endItr, float endTime)
+    {
+        while(lastItr != endItr)
+        {
+            if (lastItr->first.first < endTime) lastItr++;
+            else break;
         }
         return lastItr;
-      };
+    };
+
+    size_t nTriplets(0);
+    size_t nOrphanPairs(0);
+
+    // Structure to keep track of hit associations
+    MatchedHitMap matchedHitMap;
 
     //*********************************************************************************
     // Basically, we try to loop until done...
-    while (1) {
-      // Sort so that the earliest hit time will be the first element, etc.
-      std::sort(snippetHitMapItrVec.begin(), snippetHitMapItrVec.end(), SetStartTimeOrder());
+    while(1)
+    {
+        // Sort so that the earliest hit time will be the first element, etc.
+        std::sort(snippetHitMapItrVec.begin(),snippetHitMapItrVec.end(),SetStartTimeOrder());
 
-      // Make sure there are still hits on at least
-      int nPlanesWithHits(0);
+        // Make sure there are still hits on at least
+        int nPlanesWithHits(0);
 
-      for (auto& pair : snippetHitMapItrVec)
-        if (pair.first != pair.second) nPlanesWithHits++;
+        for(auto& pair : snippetHitMapItrVec)
+            if (pair.first != pair.second) nPlanesWithHits++;
 
-      if (nPlanesWithHits < 2) break;
+        if (nPlanesWithHits < 2) break;
 
-      // This loop iteration's snippet iterator
-      SnippetHitMap::iterator firstSnippetItr = snippetHitMapItrVec.front().first;
+        // End condition: no more hit snippets
+//        if (snippetHitMapItrVec.front().first == snippetHitMapItrVec.front().second) break;
 
-      // Set iterators to insure we'll be in the overlap ranges
-      SnippetHitMap::iterator snippetHitMapItr1Start = SetStartIterator(
-        snippetHitMapItrVec[1].first, snippetHitMapItrVec[1].second, firstSnippetItr->first.first);
-      SnippetHitMap::iterator snippetHitMapItr1End = SetEndIterator(
-        snippetHitMapItr1Start, snippetHitMapItrVec[1].second, firstSnippetItr->first.second);
-      SnippetHitMap::iterator snippetHitMapItr2Start = SetStartIterator(
-        snippetHitMapItrVec[2].first, snippetHitMapItrVec[2].second, firstSnippetItr->first.first);
-      SnippetHitMap::iterator snippetHitMapItr2End = SetEndIterator(
-        snippetHitMapItr2Start, snippetHitMapItrVec[2].second, firstSnippetItr->first.second);
+        // This loop iteration's snippet iterator
+        SnippetHitMap::iterator firstSnippetItr = snippetHitMapItrVec.front().first;
 
-      // Since we'll use these many times in the internal loops, pre make the pairs for the second set of hits
-      HitMatchTripletVecMap pair12Map;
-      HitMatchTripletVecMap pair13Map;
+        // Set iterators to insure we'll be in the overlap ranges
+        SnippetHitMap::iterator snippetHitMapItr1Start = SetStartIterator(snippetHitMapItrVec[1].first, snippetHitMapItrVec[1].second, firstSnippetItr->first.first);
+        SnippetHitMap::iterator snippetHitMapItr1End   = SetEndIterator( snippetHitMapItr1Start,        snippetHitMapItrVec[1].second, firstSnippetItr->first.second);
+        SnippetHitMap::iterator snippetHitMapItr2Start = SetStartIterator(snippetHitMapItrVec[2].first, snippetHitMapItrVec[2].second, firstSnippetItr->first.first);
+        SnippetHitMap::iterator snippetHitMapItr2End   = SetEndIterator( snippetHitMapItr2Start,        snippetHitMapItrVec[2].second, firstSnippetItr->first.second);
 
-      size_t n12Pairs =
-        findGoodHitPairs(firstSnippetItr, snippetHitMapItr1Start, snippetHitMapItr1End, pair12Map);
-      size_t n13Pairs =
-        findGoodHitPairs(firstSnippetItr, snippetHitMapItr2Start, snippetHitMapItr2End, pair13Map);
+        // Since we'll use these many times in the internal loops, pre make the pairs for the second set of hits
+        size_t                curHitListSize(hitPairList.size());
+        HitMatchTripletVecMap pair12Map;
+        HitMatchTripletVecMap pair13Map;
 
-      if (n12Pairs > n13Pairs)
-        findGoodTriplets(pair12Map, pair13Map, hitPairList);
-      else
-        findGoodTriplets(pair13Map, pair12Map, hitPairList);
+        size_t n12Pairs = findGoodHitPairs(firstSnippetItr, snippetHitMapItr1Start, snippetHitMapItr1End, pair12Map);
+        size_t n13Pairs = findGoodHitPairs(firstSnippetItr, snippetHitMapItr2Start, snippetHitMapItr2End, pair13Map);
 
-      snippetHitMapItrVec.front().first++;
-    }
+        curHitListSize  = hitPairList.size();
 
-    return hitPairList.size();
-  }
+        if (n12Pairs > n13Pairs) findGoodTriplets(pair12Map, pair13Map, matchedHitMap, hitPairList);
+        else                     findGoodTriplets(pair13Map, pair12Map, matchedHitMap, hitPairList);
 
-  int SnippetHit3DBuilder::findGoodHitPairs(SnippetHitMap::iterator& firstSnippetItr,
-                                            SnippetHitMap::iterator& startItr,
-                                            SnippetHitMap::iterator& endItr,
-                                            HitMatchTripletVecMap& hitMatchMap) const
-  {
-    int numPairs(0);
-
-    HitVector::iterator firstMaxItr =
-      std::max_element(firstSnippetItr->second.begin(),
-                       firstSnippetItr->second.end(),
-                       [](const auto& left, const auto& right) {
-                         return left->getHit()->PeakAmplitude() < right->getHit()->PeakAmplitude();
-                       });
-    float firstPHCut = firstMaxItr != firstSnippetItr->second.end() ?
-                         m_pulseHeightFrac * (*firstMaxItr)->getHit()->PeakAmplitude() :
-                         4096.;
-
-    // Loop through the hits on the first snippet
-    for (const auto& hit1 : firstSnippetItr->second) {
-      // Let's focus on the largest hit in the chain
-      if (hit1->getHit()->DegreesOfFreedom() > 1 && hit1->getHit()->PeakAmplitude() < firstPHCut &&
-          hit1->getHit()->PeakAmplitude() < m_PHLowSelection)
-        continue;
-
-      // Inside loop iterator
-      SnippetHitMap::iterator secondHitItr = startItr;
-
-      // Loop through the input secon hits and make pairs
-      while (secondHitItr != endItr) {
-        HitVector::iterator secondMaxItr = std::max_element(
-          secondHitItr->second.begin(),
-          secondHitItr->second.end(),
-          [](const auto& left, const auto& right) {
-            return left->getHit()->PeakAmplitude() < right->getHit()->PeakAmplitude();
-          });
-        float secondPHCut = secondMaxItr != secondHitItr->second.end() ?
-                              m_pulseHeightFrac * (*secondMaxItr)->getHit()->PeakAmplitude() :
-                              0.;
-
-        for (const auto& hit2 : secondHitItr->second) {
-          // Again, focus on the large hits
-          if (hit2->getHit()->DegreesOfFreedom() > 1 &&
-              hit2->getHit()->PeakAmplitude() < secondPHCut &&
-              hit2->getHit()->PeakAmplitude() < m_PHLowSelection)
-            continue;
-
-          reco::ClusterHit3D pair;
-
-          // pair returned with a negative ave time is signal of failure
-          if (!makeHitPair(pair, hit1, hit2, m_hitWidthSclFctr)) continue;
-
-          std::vector<const recob::Hit*> recobHitVec = {nullptr, nullptr, nullptr};
-
-          recobHitVec[hit1->WireID().Plane] = hit1->getHit();
-          recobHitVec[hit2->WireID().Plane] = hit2->getHit();
-
-          geo::WireID wireID = hit2->WireID();
-
-          hitMatchMap[wireID].emplace_back(hit1, hit2, pair);
-
-          numPairs++;
+        if (m_saveBadChannelPairs)
+        {
+            nOrphanPairs += saveBadChannelPairs(pair12Map, matchedHitMap, hitPairList);
+            nOrphanPairs += saveBadChannelPairs(pair13Map, matchedHitMap, hitPairList);
         }
 
-        secondHitItr++;
-      }
+        if (m_saveMythicalPoints)
+        {
+            nOrphanPairs += saveOrphanPairs(pair12Map, matchedHitMap, hitPairList);
+            nOrphanPairs += saveOrphanPairs(pair13Map, matchedHitMap, hitPairList);
+        }
+
+        nTriplets += hitPairList.size() - curHitListSize;
+
+        snippetHitMapItrVec.front().first++;
+    }
+
+    mf::LogDebug("SnippetHit3D") << "--> Created " << nTriplets << " triplets of which " << nOrphanPairs << " are orphans" << std::endl;
+
+    return hitPairList.size();
+}
+
+int SnippetHit3DBuilder::findGoodHitPairs(SnippetHitMap::iterator& firstSnippetItr,
+                                             SnippetHitMap::iterator& startItr,
+                                             SnippetHitMap::iterator& endItr,
+                                             HitMatchTripletVecMap&   hitMatchMap) const
+{
+    int numPairs(0);
+
+    HitVector::iterator firstMaxItr = std::max_element(firstSnippetItr->second.begin(),firstSnippetItr->second.end(),[](const auto& left, const auto& right){return left->getHit()->PeakAmplitude() < right->getHit()->PeakAmplitude();});
+    float               firstPHCut  = firstMaxItr != firstSnippetItr->second.end() ? m_pulseHeightFrac * (*firstMaxItr)->getHit()->PeakAmplitude() : 4096.;
+
+    // Loop through the hits on the first snippet
+    for(const auto& hit1 : firstSnippetItr->second)
+    {
+        // Let's focus on the largest hit in the chain
+        if (hit1->getHit()->DegreesOfFreedom() > 1 && hit1->getHit()->PeakAmplitude() < firstPHCut && hit1->getHit()->PeakAmplitude() < m_PHLowSelection) continue;
+
+        // Inside loop iterator
+        SnippetHitMap::iterator secondHitItr = startItr;
+
+        // Loop through the input secon hits and make pairs
+        while(secondHitItr != endItr)
+        {
+            HitVector::iterator secondMaxItr = std::max_element(secondHitItr->second.begin(),secondHitItr->second.end(),[](const auto& left, const auto& right){return left->getHit()->PeakAmplitude() < right->getHit()->PeakAmplitude();});
+            float               secondPHCut  = secondMaxItr != secondHitItr->second.end() ? m_pulseHeightFrac * (*secondMaxItr)->getHit()->PeakAmplitude() : 0.;
+
+            for(const auto& hit2 : secondHitItr->second)
+            {
+                // Again, focus on the large hits
+                if (hit2->getHit()->DegreesOfFreedom() > 1 && hit2->getHit()->PeakAmplitude() < secondPHCut && hit2->getHit()->PeakAmplitude() < m_PHLowSelection) continue;
+
+                reco::ClusterHit3D  pair;
+
+                // pair returned with a negative ave time is signal of failure
+                if (!makeHitPair(pair, hit1, hit2, m_hitWidthSclFctr)) continue;
+
+                std::vector<const recob::Hit*> recobHitVec = {nullptr,nullptr,nullptr};
+
+                recobHitVec[hit1->WireID().Plane] = hit1->getHit();
+                recobHitVec[hit2->WireID().Plane] = hit2->getHit();
+
+                geo::WireID wireID = hit2->WireID();
+
+                hitMatchMap[wireID].emplace_back(hit1,hit2,pair);
+
+                numPairs++;
+            }
+
+            secondHitItr++;
+        }
     }
 
     return numPairs;
-  }
+}
 
-  void SnippetHit3DBuilder::findGoodTriplets(HitMatchTripletVecMap& pair12Map,
-                                             HitMatchTripletVecMap& pair13Map,
-                                             reco::HitPairList& hitPairList) const
-  {
+void SnippetHit3DBuilder::findGoodTriplets(HitMatchTripletVecMap& pair12Map, 
+                                              HitMatchTripletVecMap& pair13Map, 
+                                              MatchedHitMap&         matchedHitMap,
+                                              reco::HitPairList&     hitPairList, 
+                                              bool                   tagged) const
+{
     // Build triplets from the two lists of hit pairs
-    if (!pair12Map.empty()) {
-      // temporary container for dead channel hits
-      std::vector<reco::ClusterHit3D> tempDeadChanVec;
-      reco::ClusterHit3D deadChanPair;
+    if (!pair12Map.empty() && !pair13Map.empty())
+    {
+        // temporary container for dead channel hits
+        std::vector<reco::ClusterHit3D> tempDeadChanVec;
+        reco::ClusterHit3D              deadChanPair;
 
-      // Keep track of which third plane hits have been used
-      std::map<const reco::ClusterHit3D*, bool> usedPairMap;
+        // Keep track of which third plane hits have been used
+        std::map<const reco::ClusterHit3D*,bool> usedPairMap;
 
-      // Initial population of this map with the pair13Map hits
-      for (const auto& pair13 : pair13Map) {
-        for (const auto& hit2Dhit3DPair : pair13.second)
-          usedPairMap[&std::get<2>(hit2Dhit3DPair)] = false;
-      }
+        // Initial population of this map with the pair13Map hits
+        for(const auto& pair13 : pair13Map)
+        {
+            for(const auto& hit2Dhit3DPair : pair13.second) usedPairMap[&std::get<2>(hit2Dhit3DPair)] = false;
+        }
 
-      // The outer loop is over all hit pairs made from the first two plane combinations
-      for (const auto& pair12 : pair12Map) {
-        if (pair12.second.empty()) continue;
+        // The outer loop is over all hit pairs made from the first two plane combinations
+        for(const auto& pair12 : pair12Map)
+        {
+            if (pair12.second.empty()) continue;
 
-        // This loop is over hit pairs that share the same first two plane wires but may have different
-        // hit times on those wires
-        for (const auto& hit2Dhit3DPair12 : pair12.second) {
-          const reco::ClusterHit3D& pair1 = std::get<2>(hit2Dhit3DPair12);
+            // This loop is over hit pairs that share the same first two plane wires but may have different
+            // hit times on those wires
+            for(const auto& hit2Dhit3DPair12 : pair12.second)
+            {
+                const reco::ClusterHit3D& pair1  = std::get<2>(hit2Dhit3DPair12);
 
-          // populate the map with initial value
-          usedPairMap[&pair1] = false;
+                // populate the map with initial value
+                usedPairMap[&pair1] = false;
 
-          // The simplest approach here is to loop over all possibilities and let the triplet builder weed out the weak candidates
-          for (const auto& pair13 : pair13Map) {
-            if (pair13.second.empty()) continue;
+                // The simplest approach here is to loop over all possibilities and let the triplet builder weed out the weak candidates
+                for(const auto& pair13 : pair13Map)
+                {
+                    if (pair13.second.empty()) continue;
 
-            for (const auto& hit2Dhit3DPair13 : pair13.second) {
-              // Protect against double counting
-              if (std::get<0>(hit2Dhit3DPair12) != std::get<0>(hit2Dhit3DPair13)) continue;
+                    for(const auto& hit2Dhit3DPair13 : pair13.second)
+                    {
+                        // Protect against double counting
+                        if (std::get<0>(hit2Dhit3DPair12) != std::get<0>(hit2Dhit3DPair13)) continue;
 
-              const reco::ClusterHit2D* hit2 = std::get<1>(hit2Dhit3DPair13);
-              const reco::ClusterHit3D& pair2 = std::get<2>(hit2Dhit3DPair13);
+                        const reco::ClusterHit2D* hit2  = std::get<1>(hit2Dhit3DPair13);
+                        const reco::ClusterHit3D& pair2 = std::get<2>(hit2Dhit3DPair13);
 
-              // If success try for the triplet
-              reco::ClusterHit3D triplet;
+                        // If success try for the triplet
+                        reco::ClusterHit3D triplet;
 
-              if (makeHitTriplet(triplet, pair1, hit2)) {
-                triplet.setID(hitPairList.size());
-                hitPairList.emplace_back(triplet);
-                usedPairMap[&pair1] = true;
-                usedPairMap[&pair2] = true;
-              }
+                        if (makeHitTriplet(triplet, matchedHitMap, pair1, hit2))
+                        {
+                            triplet.setID(hitPairList.size());
+                            hitPairList.emplace_back(triplet);
+                            usedPairMap[&pair1] = true;
+                            usedPairMap[&pair2] = true;
+                        }
+                    }
+                }
             }
-          }
         }
-      }
-
-      // One more loop through the other pairs to check for sick channels
-      if (m_numBadChannels > 0) {
-        for (const auto& pairMapPair : usedPairMap) {
-          if (pairMapPair.second) continue;
-
-          const reco::ClusterHit3D* pair = pairMapPair.first;
-
-          // Here we look to see if we failed to make a triplet because the partner wire was dead/noisy/sick
-          if (makeDeadChannelPair(deadChanPair, *pair, 4, 0))
-            tempDeadChanVec.emplace_back(deadChanPair);
-        }
-
-        // Handle the dead wire triplets
-        if (!tempDeadChanVec.empty()) {
-          // If we have many then see if we can trim down a bit by keeping those with time significance
-          if (tempDeadChanVec.size() > 1) {
-            // Sort by "significance" of agreement
-            std::sort(tempDeadChanVec.begin(),
-                      tempDeadChanVec.end(),
-                      [](const auto& left, const auto& right) {
-                        return left.getDeltaPeakTime() / left.getSigmaPeakTime() <
-                               right.getDeltaPeakTime() / right.getSigmaPeakTime();
-                      });
-
-            // What is the range of "significance" from first to last?
-            float firstSig = tempDeadChanVec.front().getDeltaPeakTime() /
-                             tempDeadChanVec.front().getSigmaPeakTime();
-            float lastSig =
-              tempDeadChanVec.back().getDeltaPeakTime() / tempDeadChanVec.back().getSigmaPeakTime();
-            float sigRange = lastSig - firstSig;
-
-            if (lastSig > 0.5 * m_deltaPeakTimeSig && sigRange > 0.5) {
-              // Declare a maximum of 1.5 * the average of the first and last pairs...
-              float maxSignificance = std::max(0.75 * (firstSig + lastSig), 1.0);
-
-              std::vector<reco::ClusterHit3D>::iterator firstBadElem = std::find_if(
-                tempDeadChanVec.begin(),
-                tempDeadChanVec.end(),
-                [&maxSignificance](const auto& pair) {
-                  return pair.getDeltaPeakTime() / pair.getSigmaPeakTime() > maxSignificance;
-                });
-
-              // But only keep the best 10?
-              if (std::distance(tempDeadChanVec.begin(), firstBadElem) > 20)
-                firstBadElem = tempDeadChanVec.begin() + 20;
-              // Keep at least one hit...
-              else if (firstBadElem == tempDeadChanVec.begin())
-                firstBadElem++;
-
-              tempDeadChanVec.resize(std::distance(tempDeadChanVec.begin(), firstBadElem));
-            }
-          }
-
-          for (auto& pair : tempDeadChanVec) {
-            pair.setID(hitPairList.size());
-            hitPairList.emplace_back(pair);
-          }
-        }
-      }
     }
 
     return;
-  }
+}
 
-  bool SnippetHit3DBuilder::makeHitPair(reco::ClusterHit3D& hitPair,
-                                        const reco::ClusterHit2D* hit1,
-                                        const reco::ClusterHit2D* hit2,
-                                        float hitWidthSclFctr,
-                                        size_t hitPairCntr) const
-  {
+int SnippetHit3DBuilder::saveOrphanPairs(HitMatchTripletVecMap& pairMap, MatchedHitMap& matchedHitMap, reco::HitPairList& hitPairList) const
+{
+    int curTripletCount = hitPairList.size();
+
+    // Build triplets from the two lists of hit pairs
+    if (!pairMap.empty())
+    {
+        // Initial population of this map with the pair13Map hits
+        for(const auto& pair : pairMap)
+        {
+            if (pair.second.empty()) continue;
+
+            // This loop is over hit pairs that share the same first two plane wires but may have different
+            // hit times on those wires
+            for(const auto& hit2Dhit3DPair : pair.second)
+            {
+                const reco::ClusterHit3D& hit3D = std::get<2>(hit2Dhit3DPair);
+
+                // No point considering a 3D hit that has been used to make a space point already
+                if (hit3D.getStatusBits() & reco::ClusterHit3D::MADESPACEPOINT) continue;
+
+                const reco::ClusterHit2D* hit1 = std::get<0>(hit2Dhit3DPair);
+                const reco::ClusterHit2D* hit2 = std::get<1>(hit2Dhit3DPair);
+
+                // Have these already been used in some fashion?
+                if (matchedHitMap[hit1].find(hit2) != matchedHitMap[hit1].end()) continue;
+
+                if (m_outputHistograms)
+                {
+                    m_2hit1stPHVec.emplace_back(hit1->getHit()->PeakAmplitude());
+                    m_2hit2ndPHVec.emplace_back(hit2->getHit()->PeakAmplitude());
+                    m_2hitDeltaPHVec.emplace_back(hit2->getHit()->PeakAmplitude() - hit1->getHit()->PeakAmplitude());
+                    m_2hitSumPHVec.emplace_back(hit2->getHit()->PeakAmplitude() + hit1->getHit()->PeakAmplitude());
+                }
+
+                // If both hits already appear in a triplet then there is no gain here so reject
+                if (hit1->getHit()->PeakAmplitude() < m_minPHFor2HitPoints || hit2->getHit()->PeakAmplitude() < m_minPHFor2HitPoints) continue;
+
+                // Require that one of the hits is on the collection plane
+                if (hit1->WireID().Plane == 2 || hit2->WireID().Plane == 2)
+                {
+                    // Allow cut on the quality of the space point
+                    if (hit3D.getHitChiSquare() < m_maxMythicalChiSquare)
+                    {
+                        // Add to the list
+                        hitPairList.emplace_back(hit3D);
+                        hitPairList.back().setID(hitPairList.size()-1);
+                        matchedHitMap[hit1].insert(hit2);
+                        matchedHitMap[hit2].insert(hit1);
+                    }
+                }
+            }
+        }
+    }
+
+    return hitPairList.size() - curTripletCount;
+}
+
+int SnippetHit3DBuilder::saveBadChannelPairs(HitMatchTripletVecMap& pairMap, MatchedHitMap& matchedHitMap, reco::HitPairList& hitPairList) const
+{
+    int curTripletCount = hitPairList.size();
+
+    // Assuming we havebad channels and the pairmap is not empty...
+    if (!m_channelFilter->NoisyChannels().empty() && !pairMap.empty())
+    {
+        // Initial population of this map with the pairMap hits
+        for(const auto& pair : pairMap)
+        {
+            if (pair.second.empty()) continue;
+
+            // This loop is over hit pairs that share the same first two plane wires but may have different
+            // hit times on those wires
+            for(const auto& hit2Dhit3DPair : pair.second)
+            {
+                const reco::ClusterHit3D& hit3D = std::get<2>(hit2Dhit3DPair);
+
+                // No point considering a 3D hit that has been used to make a space point already
+                if (hit3D.getStatusBits() & reco::ClusterHit3D::MADESPACEPOINT) continue;
+
+                const reco::ClusterHit2D* hit0 = std::get<0>(hit2Dhit3DPair);
+                const reco::ClusterHit2D* hit1 = std::get<1>(hit2Dhit3DPair);
+
+                // Have both of these hits already been used in some fashion?
+                if (matchedHitMap.find(hit0) != matchedHitMap.end() && matchedHitMap[hit0].find(hit1) != matchedHitMap[hit0].end()) continue;
+
+                // Which plane is missing?
+                geo::WireID wireID0 = hit0->WireID();
+                geo::WireID wireID1 = hit1->WireID();
+
+                // Determine the missing plane
+                int missPlane = 3 - (wireID0.Plane + wireID1.Plane);
+        
+                // Ok, recover the wireID expected in the third plane...
+                geo::WireID wireIn(wireID0.Cryostat,wireID0.TPC,missPlane,0);
+                geo::WireID wireID = NearestWireID(hit3D.getPosition(), wireIn);
+        
+                raw::ChannelID_t channel = m_wireReadoutAlg->PlaneWireToChannel(wireID);
+        
+                geo::WireID wireIDNext(wireID.Cryostat,wireID.TPC,wireID.Plane,wireID.Wire+1);
+                raw::ChannelID_t chanNext = m_wireReadoutAlg->PlaneWireToChannel(wireIDNext);
+        
+                bool wireStatus    =  m_channelFilter->IsPresent(channel)  && !m_channelFilter->IsGood(channel);
+                bool wireOneStatus =  m_channelFilter->IsPresent(chanNext) && !m_channelFilter->IsGood(chanNext);
+
+                // Make sure they are of at least the minimum status
+                if(wireStatus || wireOneStatus)
+                {
+                    // Sort out which is the wire we're dealing with
+                    if (!wireStatus) wireID = wireIDNext;
+
+                    // Want to refine position since we "know" the missing wire
+                    if (auto widIntersect0 = m_wireReadoutAlg->WireIDsIntersect(wireID0, wireID))
+                    {
+                        if (auto widIntersect1 = m_wireReadoutAlg->WireIDsIntersect(wireID1, wireID))
+                        {
+                            Eigen::Vector3f newPosition(hit3D.getPosition()[0],hit3D.getPosition()[1],hit3D.getPosition()[2]);
+
+                            newPosition[1] = (newPosition[1] + widIntersect0->y + widIntersect1->y) / 3.;
+                            newPosition[2] = (newPosition[2] + widIntersect0->z + widIntersect1->z - 2. * m_zPosOffset) / 3.;
+
+                            hit3D.setPosition(newPosition);
+        
+                            if (hit0->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET) hit0->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
+                            if (hit1->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET) hit1->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
+        
+                            hit0->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
+                            hit1->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
+        
+                            // Add to the list
+                            hitPairList.emplace_back(hit3D);
+                            hitPairList.back().setID(hitPairList.size()-1);
+                            matchedHitMap[hit0].insert(hit1);
+                            matchedHitMap[hit1].insert(hit0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return hitPairList.size() - curTripletCount;
+}
+
+bool SnippetHit3DBuilder::makeHitPair(reco::ClusterHit3D&       hitPair,
+                                         const reco::ClusterHit2D* hit1,
+                                         const reco::ClusterHit2D* hit2,
+                                         float                     hitWidthSclFctr,
+                                         size_t                    hitPairCntr) const
+{
     // Assume failure
     bool result(false);
 
     // Start by checking time consistency since this is fastest
     // Wires intersect so now we can check the timing
-    float hit1Peak = hit1->getTimeTicks();
+    float hit1Peak  = hit1->getTimeTicks();
     float hit1Sigma = hit1->getHit()->RMS();
 
-    float hit2Peak = hit2->getTimeTicks();
+    float hit2Peak  = hit2->getTimeTicks();
     float hit2Sigma = hit2->getHit()->RMS();
 
     // "Long hits" are an issue... so we deal with these differently
-    int hit1NDF = hit1->getHit()->DegreesOfFreedom();
-    int hit2NDF = hit2->getHit()->DegreesOfFreedom();
+    int   hit1NDF   = hit1->getHit()->DegreesOfFreedom();
+    int   hit2NDF   = hit2->getHit()->DegreesOfFreedom();
 
     // Basically, allow the range to extend to the nearest end of the snippet
-    if (hit1NDF < 2)
-      hit1Sigma *= m_LongHitStretchFctr; // This sets the range to the width of the pulse
+    if (hit1NDF < 2) hit1Sigma *= m_LongHitStretchFctr; // This sets the range to the width of the pulse
     if (hit2NDF < 2) hit2Sigma *= m_LongHitStretchFctr;
 
     // The "hit sigma" is the gaussian fit sigma of the hit, we need to expand a bit to allow hit overlap efficiency
@@ -907,407 +1058,477 @@ namespace lar_cluster3d {
     float hit2Width = hitWidthSclFctr * hit2Sigma;
 
     // Coarse check hit times are "in range"
-    if (fabs(hit1Peak - hit2Peak) <= (hit1Width + hit2Width)) {
-      // Check to see that hit peak times are consistent with each other
-      float hit1SigSq = hit1Sigma * hit1Sigma;
-      float hit2SigSq = hit2Sigma * hit2Sigma;
-      float deltaPeakTime = std::fabs(hit1Peak - hit2Peak);
-      float sigmaPeakTime = std::sqrt(hit1SigSq + hit2SigSq);
+    if (fabs(hit1Peak - hit2Peak) <= (hit1Width + hit2Width))
+    {
+        // Check to see that hit peak times are consistent with each other
+        float hit1SigSq     = std::pow(hit1Sigma,2);
+        float hit2SigSq     = std::pow(hit2Sigma,2);
+        float deltaPeakTime = std::fabs(hit1Peak - hit2Peak);
+        float sigmaPeakTime = std::sqrt(hit1SigSq + hit2SigSq);
 
-      // delta peak time consistency check here
-      if (deltaPeakTime <
-          m_deltaPeakTimeSig * sigmaPeakTime) // 2 sigma consistency? (do this way to avoid divide)
-      {
-        // We assume in this routine that we are looking at hits in different views
-        // The first mission is to check that the wires intersect
-        const geo::WireID& hit1WireID = hit1->WireID();
-        const geo::WireID& hit2WireID = hit2->WireID();
+        if (m_outputHistograms)
+        {
+            // brute force... sigh... 
+            int plane1   = hit1->WireID().Plane;
+            int plane2   = hit2->WireID().Plane;
+            int planeIdx = (plane1 + plane2) - 1;     // should be 0 for 0-1, 1 for 0-2 and 2 for 1-2
 
-        geo::WireIDIntersection widIntersect;
+            float deltaTicks = hit2Peak - hit1Peak;
 
-        if (WireIDsIntersect(hit1WireID, hit2WireID, widIntersect)) {
-          float oneOverWghts = hit1SigSq * hit2SigSq / (hit1SigSq + hit2SigSq);
-          float avePeakTime = (hit1Peak / hit1SigSq + hit2Peak / hit2SigSq) * oneOverWghts;
-          float totalCharge = hit1->getHit()->Integral() + hit2->getHit()->Integral();
-          float hitChiSquare = std::pow((hit1Peak - avePeakTime), 2) / hit1SigSq +
-                               std::pow((hit2Peak - avePeakTime), 2) / hit2SigSq;
+            if (plane1 > plane2) deltaTicks = -deltaTicks;
 
-          float xPositionHit1(hit1->getXPosition());
-          float xPositionHit2(hit2->getXPosition());
-          float xPosition = (xPositionHit1 / hit1SigSq + xPositionHit2 / hit2SigSq) * hit1SigSq *
-                            hit2SigSq / (hit1SigSq + hit2SigSq);
-
-          Eigen::Vector3f position(
-            xPosition, float(widIntersect.y), float(widIntersect.z) - m_zPosOffset);
-
-          // If to here then we need to sort out the hit pair code telling what views are used
-          unsigned statusBits = 1 << hit1->WireID().Plane | 1 << hit2->WireID().Plane;
-
-          // handle status bits for the 2D hits
-          if (hit1->getStatusBits() & reco::ClusterHit2D::USEDINPAIR)
-            hit1->setStatusBit(reco::ClusterHit2D::SHAREDINPAIR);
-          if (hit2->getStatusBits() & reco::ClusterHit2D::USEDINPAIR)
-            hit2->setStatusBit(reco::ClusterHit2D::SHAREDINPAIR);
-
-          hit1->setStatusBit(reco::ClusterHit2D::USEDINPAIR);
-          hit2->setStatusBit(reco::ClusterHit2D::USEDINPAIR);
-
-          reco::ClusterHit2DVec hitVector;
-
-          hitVector.resize(3, NULL);
-
-          hitVector[hit1->WireID().Plane] = hit1;
-          hitVector[hit2->WireID().Plane] = hit2;
-
-          unsigned int cryostatIdx = hit1->WireID().Cryostat;
-          unsigned int tpcIdx = hit1->WireID().TPC;
-
-          // Initialize the wireIdVec
-          std::vector<geo::WireID> wireIDVec = {geo::WireID(cryostatIdx, tpcIdx, 0, 0),
-                                                geo::WireID(cryostatIdx, tpcIdx, 1, 0),
-                                                geo::WireID(cryostatIdx, tpcIdx, 2, 0)};
-
-          wireIDVec[hit1->WireID().Plane] = hit1->WireID();
-          wireIDVec[hit2->WireID().Plane] = hit2->WireID();
-
-          // For compiling at the moment
-          std::vector<float> hitDelTSigVec = {0., 0., 0.};
-
-          hitDelTSigVec[hit1->WireID().Plane] = deltaPeakTime / sigmaPeakTime;
-          hitDelTSigVec[hit2->WireID().Plane] = deltaPeakTime / sigmaPeakTime;
-
-          // Create the 3D cluster hit
-          hitPair.initialize(hitPairCntr,
-                             statusBits,
-                             position,
-                             totalCharge,
-                             avePeakTime,
-                             deltaPeakTime,
-                             sigmaPeakTime,
-                             hitChiSquare,
-                             0.,
-                             0.,
-                             0.,
-                             0.,
-                             hitVector,
-                             hitDelTSigVec,
-                             wireIDVec);
-
-          result = true;
+            if (planeIdx == 0)
+            {
+                m_deltaPeakTimePlane0Vec.emplace_back(deltaTicks);
+                m_deltaPeakSigmaPlane0Vec.emplace_back(sigmaPeakTime);
+            }
+            else if (planeIdx == 1)
+            {
+                m_deltaPeakTimePlane1Vec.emplace_back(deltaTicks);
+                m_deltaPeakSigmaPlane1Vec.emplace_back(sigmaPeakTime);
+            }
+            else
+            {
+                m_deltaPeakTimePlane2Vec.emplace_back(deltaTicks);
+                m_deltaPeakSigmaPlane2Vec.emplace_back(sigmaPeakTime);
+            }
         }
-      }
+
+        // delta peak time consistency check here
+        if (deltaPeakTime < m_deltaPeakTimeSig * sigmaPeakTime)    // 2 sigma consistency? (do this way to avoid divide)
+        {
+            // We assume in this routine that we are looking at hits in different views
+            // The first mission is to check that the wires intersect
+            const geo::WireID& hit1WireID = hit1->WireID();
+            const geo::WireID& hit2WireID = hit2->WireID();
+
+            geo::WireIDIntersection widIntersect;
+
+            if (WireIDsIntersect(hit1WireID, hit2WireID, widIntersect))
+            {
+                float oneOverWghts  = hit1SigSq * hit2SigSq / (hit1SigSq + hit2SigSq);
+                float avePeakTime   = (hit1Peak / hit1SigSq + hit2Peak / hit2SigSq) * oneOverWghts;
+                float averageCharge = 0.5 * (hit1->getHit()->Integral() + hit2->getHit()->Integral());
+                float hitChiSquare  = std::pow((hit1Peak - avePeakTime),2) / hit1SigSq
+                                    + std::pow((hit2Peak - avePeakTime),2) / hit2SigSq;
+
+                float xPositionHit1(hit1->getXPosition());
+                float xPositionHit2(hit2->getXPosition());
+                float xPosition = (xPositionHit1 / hit1SigSq + xPositionHit2 / hit2SigSq) * hit1SigSq * hit2SigSq / (hit1SigSq + hit2SigSq);
+
+                Eigen::Vector3f position(xPosition, float(widIntersect.y), float(widIntersect.z)-m_zPosOffset);
+
+                // If to here then we need to sort out the hit pair code telling what views are used
+                unsigned statusBits = 1 << hit1->WireID().Plane | 1 << hit2->WireID().Plane;
+
+                // handle status bits for the 2D hits
+                if (hit1->getStatusBits() & reco::ClusterHit2D::USEDINPAIR) hit1->setStatusBit(reco::ClusterHit2D::SHAREDINPAIR);
+                if (hit2->getStatusBits() & reco::ClusterHit2D::USEDINPAIR) hit2->setStatusBit(reco::ClusterHit2D::SHAREDINPAIR);
+
+                hit1->setStatusBit(reco::ClusterHit2D::USEDINPAIR);
+                hit2->setStatusBit(reco::ClusterHit2D::USEDINPAIR);
+
+                reco::ClusterHit2DVec hitVector;
+
+                hitVector.resize(3, NULL);
+
+                hitVector[hit1->WireID().Plane] = hit1;
+                hitVector[hit2->WireID().Plane] = hit2;
+
+                unsigned int cryostatIdx = hit1->WireID().Cryostat;
+                unsigned int tpcIdx      = hit1->WireID().TPC;
+
+                // Initialize the wireIdVec
+                std::vector<geo::WireID> wireIDVec = {geo::WireID(cryostatIdx,tpcIdx,0,0),
+                                                      geo::WireID(cryostatIdx,tpcIdx,1,0),
+                                                      geo::WireID(cryostatIdx,tpcIdx,2,0)};
+
+                wireIDVec[hit1->WireID().Plane] = hit1->WireID();
+                wireIDVec[hit2->WireID().Plane] = hit2->WireID();
+
+                // For compiling at the moment
+                std::vector<float> hitDelTSigVec = {0.,0.,0.};
+
+                hitDelTSigVec[hit1->WireID().Plane] = deltaPeakTime / sigmaPeakTime;
+                hitDelTSigVec[hit2->WireID().Plane] = deltaPeakTime / sigmaPeakTime;
+
+                // Create the 3D cluster hit
+                hitPair.initialize(hitPairCntr,
+                                   statusBits,
+                                   position,
+                                   averageCharge,
+                                   avePeakTime,
+                                   deltaPeakTime,
+                                   sigmaPeakTime,
+                                   hitChiSquare,
+                                   0.,
+                                   0.,
+                                   0.,
+                                   0.,
+                                   hitVector,
+                                   hitDelTSigVec,
+                                   wireIDVec);
+
+                result = true;
+            }
+        }
     }
 
     // Send it back
     return result;
-  }
+}
 
-  bool SnippetHit3DBuilder::makeHitTriplet(reco::ClusterHit3D& hitTriplet,
-                                           const reco::ClusterHit3D& pair,
-                                           const reco::ClusterHit2D* hit) const
-  {
+
+bool SnippetHit3DBuilder::makeHitTriplet(reco::ClusterHit3D&       hitTriplet,
+                                            MatchedHitMap&            matchedHitMap,
+                                            const reco::ClusterHit3D& pair,
+                                            const reco::ClusterHit2D* hit) const
+{
     // Assume failure
     bool result(false);
 
     // We are going to force the wire pitch here, some time in the future we need to fix
-    static const double wirePitch =
-      0.5 * m_wirePitchScaleFactor * *std::max_element(m_wirePitch, m_wirePitch + 3);
+    static const double wirePitch = 0.5 * m_wirePitchScaleFactor * *std::max_element(m_wirePitch,m_wirePitch+3);
 
     // Recover hit info
     float hitTimeTicks = hit->getTimeTicks();
-    float hitSigma = hit->getHit()->RMS();
+    float hitSigma     = hit->getHit()->RMS();
 
     // Special case check
-    if (hitSigma > 2. * hit->getHit()->PeakAmplitude())
-      hitSigma = 2. * hit->getHit()->PeakAmplitude();
+    if (hitSigma > 2. * hit->getHit()->PeakAmplitude()) hitSigma = 2. * hit->getHit()->PeakAmplitude();
 
     // Let's do a quick consistency check on the input hits to make sure we are in range...
     // Require the W hit to be "in range" with the UV Pair
-    if (fabs(hitTimeTicks - pair.getAvePeakTime()) <
-        m_hitWidthSclFctr * (pair.getSigmaPeakTime() + hitSigma)) {
-      // Check the distance from the point to the wire the hit is on
-      float hitWireDist = DistanceFromPointToHitWire(pair.getPosition(), hit->WireID());
+    if (fabs(hitTimeTicks - pair.getAvePeakTime()) < m_hitWidthSclFctr * (pair.getSigmaPeakTime() + hitSigma))
+    {
+        // Check the distance from the point to the wire the hit is on
+        float hitWireDist = DistanceFromPointToHitWire(pair.getPosition(), hit->WireID());
 
-      if (m_outputHistograms) m_maxSideVecVec.push_back(hitWireDist);
+        if (m_outputHistograms) m_maxSideVecVec.push_back(hitWireDist);
 
-      // Reject hits that are not within range
-      if (hitWireDist < wirePitch) {
-        if (m_outputHistograms) m_pairWireDistVec.push_back(hitWireDist);
+        // Reject hits that are not within range
+        if (hitWireDist < wirePitch)
+        {
+            if (m_outputHistograms) m_pairWireDistVec.push_back(hitWireDist);
 
-        // Use the existing code to see the U and W hits are willing to pair with the V hit
-        reco::ClusterHit3D pair0h;
-        reco::ClusterHit3D pair1h;
+            // Let's mark that this pair had a valid 3 wire combination
+            pair.setStatusBit(reco::ClusterHit3D::MADESPACEPOINT);
 
-        // Recover all the hits involved
-        const reco::ClusterHit2DVec& pairHitVec = pair.getHits();
-        const reco::ClusterHit2D* hit0 = pairHitVec[0];
-        const reco::ClusterHit2D* hit1 = pairHitVec[1];
+            // Use the existing code to see the U and W hits are willing to pair with the V hit
+            reco::ClusterHit3D pair0h;
+            reco::ClusterHit3D pair1h;
 
-        if (!hit0)
-          hit0 = pairHitVec[2];
-        else if (!hit1)
-          hit1 = pairHitVec[2];
+            // Recover all the hits involved
+            const reco::ClusterHit2DVec& pairHitVec = pair.getHits();
+            const reco::ClusterHit2D*    hit0       = pairHitVec[0];
+            const reco::ClusterHit2D*    hit1       = pairHitVec[1];
 
-        // If good pairs made here then we can try to make a triplet
-        if (makeHitPair(pair0h, hit0, hit, m_hitWidthSclFctr) &&
-            makeHitPair(pair1h, hit1, hit, m_hitWidthSclFctr)) {
-          // Get a copy of the input hit vector (note the order is by plane - by definition)
-          reco::ClusterHit2DVec hitVector = pair.getHits();
+            if      (!hit0) hit0 = pairHitVec[2];
+            else if (!hit1) hit1 = pairHitVec[2];
 
-          // include the new hit
-          hitVector[hit->WireID().Plane] = hit;
+            bool notMatched =  matchedHitMap[hit].find(hit0)  == matchedHitMap[hit].end() 
+                            && matchedHitMap[hit].find(hit1)  == matchedHitMap[hit].end()
+                            && matchedHitMap[hit0].find(hit1) == matchedHitMap[hit0].end();
 
-          // Set up to get average peak time, hitChiSquare, etc.
-          unsigned int statusBits(0x7);
-          float avePeakTime(0.);
-          float weightSum(0.);
-          float xPosition(0.);
+            // If good pairs made here then we can try to make a triplet
+            if (notMatched && makeHitPair(pair0h, hit0, hit, m_hitWidthSclFctr) && makeHitPair(pair1h, hit1, hit, m_hitWidthSclFctr))
+            {
+                // Get a copy of the input hit vector (note the order is by plane - by definition)
+                reco::ClusterHit2DVec hitVector = pair.getHits();
 
-          // And get the wire IDs
-          std::vector<geo::WireID> wireIDVec = {geo::WireID(), geo::WireID(), geo::WireID()};
+                // include the new hit
+                hitVector[hit->WireID().Plane] = hit;
 
-          // First loop through the hits to get WireIDs and calculate the averages
-          for (size_t planeIdx = 0; planeIdx < 3; planeIdx++) {
-            const reco::ClusterHit2D* hit2D = hitVector[planeIdx];
+                // Set up to get average peak time, hitChiSquare, etc.
+                unsigned int statusBits(0x7);
+                float        avePeakTime(0.);
+                float        weightSum(0.);
+                float        xPosition(0.);
 
-            wireIDVec[planeIdx] = hit2D->WireID();
+                // And get the wire IDs
+                std::vector<geo::WireID> wireIDVec = {geo::WireID(), geo::WireID(), geo::WireID()};
 
-            if (hit2D->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET)
-              hit2D->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
+                // First loop through the hits to get WireIDs and calculate the averages
+                for(size_t planeIdx = 0; planeIdx < 3; planeIdx++)
+                {
+                    const reco::ClusterHit2D* hit2D = hitVector[planeIdx];
 
-            hit2D->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
+                    wireIDVec[planeIdx] = hit2D->WireID();
 
-            float hitRMS = hit2D->getHit()->RMS();
-            float peakTime = hit2D->getTimeTicks();
+                    float hitRMS   = hit2D->getHit()->RMS();
+                    float peakTime = hit2D->getTimeTicks();
 
-            // Basically, allow the range to extend to the nearest end of the snippet
-            if (hit2D->getHit()->DegreesOfFreedom() < 2) hitRMS *= m_LongHitStretchFctr;
+                    // Basically, allow the range to extend to the nearest end of the snippet
+                    if (hit2D->getHit()->DegreesOfFreedom() < 2) hitRMS *= m_LongHitStretchFctr;
+                        //hitRMS = std::min(hit2D->getTimeTicks() - float(hit2D->getHit()->StartTick()),float(hit2D->getHit()->EndTick())-hit2D->getTimeTicks());
 
-            float weight = 1. / (hitRMS * hitRMS);
+                    float weight = 1. / (hitRMS * hitRMS);
 
-            avePeakTime += peakTime * weight;
-            xPosition += hit2D->getXPosition() * weight;
-            weightSum += weight;
-          }
+                    avePeakTime += peakTime * weight;
+                    xPosition   += hit2D->getXPosition() * weight;
+                    weightSum   += weight;
+                }
 
-          avePeakTime /= weightSum;
-          xPosition /= weightSum;
+                avePeakTime /= weightSum;
+                xPosition   /= weightSum;
 
-          Eigen::Vector2f pair0hYZVec(pair0h.getPosition()[1], pair0h.getPosition()[2]);
-          Eigen::Vector2f pair1hYZVec(pair1h.getPosition()[1], pair1h.getPosition()[2]);
-          Eigen::Vector2f pairYZVec(pair.getPosition()[1], pair.getPosition()[2]);
-          Eigen::Vector3f position(xPosition,
-                                   float((pairYZVec[0] + pair0hYZVec[0] + pair1hYZVec[0]) / 3.),
-                                   float((pairYZVec[1] + pair0hYZVec[1] + pair1hYZVec[1]) / 3.));
+                Eigen::Vector2f pair0hYZVec(pair0h.getPosition()[1],pair0h.getPosition()[2]);
+                Eigen::Vector2f pair1hYZVec(pair1h.getPosition()[1],pair1h.getPosition()[2]);
+                Eigen::Vector2f pairYZVec(pair.getPosition()[1],pair.getPosition()[2]);
+                Eigen::Vector3f position(xPosition,
+                                         float((pairYZVec[0] + pair0hYZVec[0] + pair1hYZVec[0]) / 3.),
+                                         float((pairYZVec[1] + pair0hYZVec[1] + pair1hYZVec[1]) / 3.));
 
-          // Armed with the average peak time, now get hitChiSquare and the sig vec
-          float hitChiSquare(0.);
-          float sigmaPeakTime(std::sqrt(1. / weightSum));
-          std::vector<float> hitDelTSigVec;
+                // Armed with the average peak time, now get hitChiSquare and the sig vec
+                float              hitChiSquare(0.);
+                float              sigmaPeakTime(std::sqrt(1./weightSum));
+                std::vector<float> hitDelTSigVec;
 
-          for (const auto& hit2D : hitVector) {
-            float hitRMS = hit2D->getHit()->RMS();
+                for(const auto& hit2D : hitVector)
+                {
+                    float hitRMS = hit2D->getHit()->RMS();
 
-            // Basically, allow the range to extend to the nearest end of the snippet
-            if (hit2D->getHit()->DegreesOfFreedom() < 2) hitRMS *= m_LongHitStretchFctr;
+                    // Basically, allow the range to extend to the nearest end of the snippet
+                    if (hit2D->getHit()->DegreesOfFreedom() < 2) hitRMS *= m_LongHitStretchFctr;
+                        //hitRMS = std::min(hit2D->getTimeTicks() - float(hit2D->getHit()->StartTick()),float(hit2D->getHit()->EndTick())-hit2D->getTimeTicks());
 
-            float combRMS = std::sqrt(hitRMS * hitRMS - sigmaPeakTime * sigmaPeakTime);
-            float peakTime = hit2D->getTimeTicks();
-            float deltaTime = peakTime - avePeakTime;
-            float hitSig = deltaTime / combRMS;
+                    float combRMS   = std::sqrt(hitRMS*hitRMS - sigmaPeakTime*sigmaPeakTime);
+                    float peakTime  = hit2D->getTimeTicks();
+                    float deltaTime = peakTime - avePeakTime;
+                    float hitSig    = deltaTime / combRMS;
 
-            hitChiSquare += hitSig * hitSig;
+                    hitChiSquare += hitSig * hitSig;
 
-            hitDelTSigVec.emplace_back(std::fabs(hitSig));
-          }
+                    hitDelTSigVec.emplace_back(std::fabs(hitSig));
+                }
 
-          if (m_outputHistograms) m_chiSquare3DVec.push_back(hitChiSquare);
+                if (m_outputHistograms) m_chiSquare3DVec.push_back(hitChiSquare);
 
-          int lowMinIndex(std::numeric_limits<int>::max());
-          int lowMaxIndex(std::numeric_limits<int>::min());
-          int hiMinIndex(std::numeric_limits<int>::max());
-          int hiMaxIndex(std::numeric_limits<int>::min());
+                int lowMinIndex(std::numeric_limits<int>::max());
+                int lowMaxIndex(std::numeric_limits<int>::min());
+                int hiMinIndex(std::numeric_limits<int>::max());
+                int hiMaxIndex(std::numeric_limits<int>::min());
 
-          // First task is to get the min/max values for the common overlap region
-          for (const auto& hit2D : hitVector) {
-            float range = m_rangeNumSig * hit2D->getHit()->RMS();
+                // First task is to get the min/max values for the common overlap region
+                for(const auto& hit2D : hitVector)
+                {
+                    float range = m_rangeNumSig * hit2D->getHit()->RMS();
 
-            // Basically, allow the range to extend to the nearest end of the snippet
-            if (hit2D->getHit()->DegreesOfFreedom() < 2) range *= m_LongHitStretchFctr;
+                    // Basically, allow the range to extend to the nearest end of the snippet
+                    if (hit2D->getHit()->DegreesOfFreedom() < 2) range *= m_LongHitStretchFctr;
+                        //range = std::min(hit2D->getTimeTicks() - float(hit2D->getHit()->StartTick()),float(hit2D->getHit()->EndTick())-hit2D->getTimeTicks());
 
-            int hitStart = hit2D->getHit()->PeakTime() - range - 0.5;
-            int hitStop = hit2D->getHit()->PeakTime() + range + 0.5;
+                    int hitStart = hit2D->getHit()->PeakTime() - range - 0.5;
+                    int hitStop  = hit2D->getHit()->PeakTime() + range + 0.5;
 
-            lowMinIndex = std::min(hitStart, lowMinIndex);
-            lowMaxIndex = std::max(hitStart, lowMaxIndex);
-            hiMinIndex = std::min(hitStop + 1, hiMinIndex);
-            hiMaxIndex = std::max(hitStop + 1, hiMaxIndex);
-          }
+                    lowMinIndex = std::min(hitStart,    lowMinIndex);
+                    lowMaxIndex = std::max(hitStart,    lowMaxIndex);
+                    hiMinIndex  = std::min(hitStop + 1, hiMinIndex);
+                    hiMaxIndex  = std::max(hitStop + 1, hiMaxIndex);
+                }
 
-          // Keep only "good" hits...
-          if (hitChiSquare < m_maxHit3DChiSquare && hiMinIndex > lowMaxIndex) {
-            // One more pass through hits to get charge
-            std::vector<float> chargeVec;
+                // Keep only "good" hits...
+                if (hitChiSquare < m_maxHit3DChiSquare && hiMinIndex > lowMaxIndex)
+                {
+                    // One more pass through hits to get charge
+                    std::vector<float> chargeVec;
 
-            for (const auto& hit2D : hitVector)
-              chargeVec.push_back(chargeIntegral(hit2D->getHit()->PeakTime(),
-                                                 hit2D->getHit()->PeakAmplitude(),
-                                                 hit2D->getHit()->RMS(),
-                                                 lowMaxIndex,
-                                                 hiMinIndex));
+                    for(const auto& hit2D : hitVector)
+                        chargeVec.push_back(chargeIntegral(hit2D->getHit()->PeakTime(),hit2D->getHit()->PeakAmplitude(),hit2D->getHit()->RMS(),1.,lowMaxIndex,hiMinIndex));
 
-            float totalCharge =
-              std::accumulate(chargeVec.begin(), chargeVec.end(), 0.) / float(chargeVec.size());
-            float overlapRange = float(hiMinIndex - lowMaxIndex);
-            float overlapFraction = overlapRange / float(hiMaxIndex - lowMinIndex);
+                    float totalCharge     = std::accumulate(chargeVec.begin(),chargeVec.end(),0.) / float(chargeVec.size());
+                    float overlapRange    = float(hiMinIndex - lowMaxIndex);
+                    float overlapFraction = overlapRange / float(hiMaxIndex - lowMinIndex);
 
-            // Set up to compute the charge asymmetry
-            std::vector<float> smallestChargeDiffVec;
-            std::vector<float> chargeAveVec;
-            float smallestDiff(std::numeric_limits<float>::max());
-            float maxDeltaPeak(0.);
-            size_t chargeIndex(0);
+                    // Set up to compute the charge asymmetry
+                    std::vector<float> smallestChargeDiffVec;
+                    std::vector<float> chargeAveVec;
+                    float              smallestDiff(std::numeric_limits<float>::max());
+                    float              maxDeltaPeak(0.);
+                    size_t             chargeIndex(0);
 
-            for (size_t idx = 0; idx < 3; idx++) {
-              size_t leftIdx = (idx + 2) % 3;
-              size_t rightIdx = (idx + 1) % 3;
+                    for(size_t idx = 0; idx < 3; idx++)
+                    {
+                        size_t leftIdx  = (idx + 2) % 3;
+                        size_t rightIdx = (idx + 1) % 3;
 
-              smallestChargeDiffVec.push_back(std::abs(chargeVec[leftIdx] - chargeVec[rightIdx]));
-              chargeAveVec.push_back(float(0.5 * (chargeVec[leftIdx] + chargeVec[rightIdx])));
+                        smallestChargeDiffVec.push_back(std::abs(chargeVec[leftIdx] - chargeVec[rightIdx]));
+                        chargeAveVec.push_back(float(0.5 * (chargeVec[leftIdx] + chargeVec[rightIdx])));
 
-              if (smallestChargeDiffVec.back() < smallestDiff) {
-                smallestDiff = smallestChargeDiffVec.back();
-                chargeIndex = idx;
-              }
+                        if (smallestChargeDiffVec.back() < smallestDiff)
+                        {
+                            smallestDiff = smallestChargeDiffVec.back();
+                            chargeIndex  = idx;
+                        }
 
-              // Take opportunity to look at peak time diff
-              float deltaPeakTime =
-                hitVector[leftIdx]->getTimeTicks() - hitVector[rightIdx]->getTimeTicks();
+                        // Take opportunity to look at peak time diff
+                        float deltaPeakTime = hitVector[rightIdx]->getTimeTicks() - hitVector[leftIdx]->getTimeTicks();
 
-              if (std::abs(deltaPeakTime) > maxDeltaPeak) maxDeltaPeak = std::abs(deltaPeakTime);
+                        if (std::abs(deltaPeakTime) > maxDeltaPeak) maxDeltaPeak = std::abs(deltaPeakTime);
 
-              if (m_outputHistograms) m_deltaTimeVec.push_back(deltaPeakTime);
+                        if (m_outputHistograms)
+                        {
+                            int   deltaTimeIdx = (hitVector[leftIdx]->WireID().Plane + hitVector[rightIdx]->WireID().Plane) - 1;
+                            float combRMS      = std::sqrt(std::pow(hitVector[leftIdx]->getHit()->RMS(),2) + std::pow(hitVector[rightIdx]->getHit()->RMS(),2));
+
+                            m_deltaTimeVec.push_back(deltaPeakTime);
+
+                            // Want to get the sign of the difference correct...
+                            if (deltaTimeIdx == 0)  // This is planes 1 and 0
+                            {
+                                m_deltaTime0Vec.emplace_back(float(hitVector[1]->getTimeTicks() - hitVector[0]->getTimeTicks()));
+                                m_deltaSigma0Vec.emplace_back(combRMS);
+                            }
+                            else if (deltaTimeIdx == 1)  // This is planes 0 and 2
+                            {
+                                m_deltaTime1Vec.emplace_back(float(hitVector[2]->getTimeTicks() - hitVector[0]->getTimeTicks()));
+                                m_deltaSigma1Vec.emplace_back(combRMS);
+                            }
+                            else // must be planes 1 and 2
+                            {
+                                m_deltaTime2Vec.emplace_back(float(hitVector[2]->getTimeTicks() - hitVector[1]->getTimeTicks()));
+                                m_deltaSigma2Vec.emplace_back(combRMS);
+                            }
+                        }
+                    }
+
+                    float chargeAsymmetry = (chargeAveVec[chargeIndex] - chargeVec[chargeIndex]) / (chargeAveVec[chargeIndex] + chargeVec[chargeIndex]);
+
+                    // If this is true there has to be a negative charge that snuck in somehow
+                    if (chargeAsymmetry < -1. || chargeAsymmetry > 1.)
+                    {
+                        const geo::WireID& hitWireID = hitVector[chargeIndex]->WireID();
+
+                        std::cout << "============> Charge asymmetry out of range: " << chargeAsymmetry << " <============" << std::endl;
+                        std::cout << "     hit C: " << hitWireID.Cryostat << ", TPC: " << hitWireID.TPC << ", Plane: " << hitWireID.Plane << ", Wire: " << hitWireID.Wire << std::endl;
+                        std::cout << "     charge: " << chargeVec[0] << ", " << chargeVec[1] << ", " << chargeVec[2] << std::endl;
+                        std::cout << "     index: " << chargeIndex << ", smallest diff: " << smallestDiff << std::endl;
+                        return result;
+                    }
+
+                    // Usurping "deltaPeakTime" to be the maximum pull
+                    float deltaPeakTime = *std::max_element(hitDelTSigVec.begin(),hitDelTSigVec.end());
+
+                    if (m_outputHistograms)
+                    {
+                        m_smallChargeDiffVec.push_back(smallestDiff);
+                        m_smallIndexVec.push_back(chargeIndex);
+                        m_maxPullVec.push_back(deltaPeakTime);
+                        m_qualityMetricVec.push_back(hitChiSquare);
+                        m_spacePointChargeVec.push_back(totalCharge);
+                        m_overlapFractionVec.push_back(overlapFraction);
+                        m_overlapRangeVec.push_back(overlapRange);
+                        m_maxDeltaPeakVec.push_back(maxDeltaPeak);
+                        m_hitAsymmetryVec.push_back(chargeAsymmetry);
+                    }
+
+                    // Try to weed out cases where overlap doesn't match peak separation
+                    if (maxDeltaPeak > 3. * overlapRange) return result;
+
+                    // Create the 3D cluster hit
+                    hitTriplet.initialize(0,
+                                          statusBits,
+                                          position,
+                                          totalCharge,
+                                          avePeakTime,
+                                          deltaPeakTime,
+                                          sigmaPeakTime,
+                                          hitChiSquare,
+                                          overlapFraction,
+                                          chargeAsymmetry,
+                                          0.,
+                                          0.,
+                                          hitVector,
+                                          hitDelTSigVec,
+                                          wireIDVec);
+
+                    // Since we are keeping the triplet, mark the hits as used
+                    for(size_t hit2DIdx = 0; hit2DIdx < hitVector.size(); hit2DIdx++)
+                    {
+                        const reco::ClusterHit2D* hit2D = hitVector[hit2DIdx];
+
+                        matchedHitMap[hit2D].insert(hitVector[(hit2DIdx+1)%hitVector.size()]);
+                        matchedHitMap[hit2D].insert(hitVector[(hit2DIdx+2)%hitVector.size()]);
+
+                        if (hit2D->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET) hit2D->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
+
+                        hit2D->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
+                    }
+
+                    // Mark the input pair
+                    pair.setStatusBit(reco::ClusterHit3D::MADESPACEPOINT);
+
+                    result = true;
+                }
+//                else mf::LogDebug("SnippetHit3D") << "-Rejecting triple with chiSquare: " << hitChiSquare << " and hiMinIndex: " << hiMinIndex << ", loMaxIndex: " << lowMaxIndex;
             }
-
-            float chargeAsymmetry = (chargeAveVec[chargeIndex] - chargeVec[chargeIndex]) /
-                                    (chargeAveVec[chargeIndex] + chargeVec[chargeIndex]);
-
-            // If this is true there has to be a negative charge that snuck in somehow
-            if (chargeAsymmetry < -1. || chargeAsymmetry > 1.) {
-              const geo::WireID& hitWireID = hitVector[chargeIndex]->WireID();
-
-              std::cout << "============> Charge asymmetry out of range: " << chargeAsymmetry
-                        << " <============" << std::endl;
-              std::cout << "     hit C: " << hitWireID.Cryostat << ", TPC: " << hitWireID.TPC
-                        << ", Plane: " << hitWireID.Plane << ", Wire: " << hitWireID.Wire
-                        << std::endl;
-              std::cout << "     charge: " << chargeVec[0] << ", " << chargeVec[1] << ", "
-                        << chargeVec[2] << std::endl;
-              std::cout << "     index: " << chargeIndex << ", smallest diff: " << smallestDiff
-                        << std::endl;
-              return result;
-            }
-
-            // Usurping "deltaPeakTime" to be the maximum pull
-            float deltaPeakTime = *std::max_element(hitDelTSigVec.begin(), hitDelTSigVec.end());
-
-            if (m_outputHistograms) {
-              m_smallChargeDiffVec.push_back(smallestDiff);
-              m_smallIndexVec.push_back(chargeIndex);
-              m_maxPullVec.push_back(deltaPeakTime);
-              m_qualityMetricVec.push_back(hitChiSquare);
-              m_spacePointChargeVec.push_back(totalCharge);
-              m_overlapFractionVec.push_back(overlapFraction);
-              m_overlapRangeVec.push_back(overlapRange);
-              m_maxDeltaPeakVec.push_back(maxDeltaPeak);
-              m_hitAsymmetryVec.push_back(chargeAsymmetry);
-            }
-
-            // Try to weed out cases where overlap doesn't match peak separation
-            if (maxDeltaPeak > 3. * overlapRange) return result;
-
-            // Create the 3D cluster hit
-            hitTriplet.initialize(0,
-                                  statusBits,
-                                  position,
-                                  totalCharge,
-                                  avePeakTime,
-                                  deltaPeakTime,
-                                  sigmaPeakTime,
-                                  hitChiSquare,
-                                  overlapFraction,
-                                  chargeAsymmetry,
-                                  0.,
-                                  0.,
-                                  hitVector,
-                                  hitDelTSigVec,
-                                  wireIDVec);
-
-            result = true;
-          }
         }
-      }
     }
+//    else mf::LogDebug("SnippetHit3D") << "-MakeTriplet hit cut, delta: " << hitTimeTicks - pair.getAvePeakTime() << ", min scale fctr: " <<m_hitWidthSclFctr << ", pair sig: " << pair.getSigmaPeakTime() << ", hitSigma: " << hitSigma << std::endl;
 
     // return success/fail
     return result;
-  }
+}
 
-  bool SnippetHit3DBuilder::WireIDsIntersect(const geo::WireID& wireID0,
-                                             const geo::WireID& wireID1,
-                                             geo::WireIDIntersection& widIntersection) const
-  {
+bool SnippetHit3DBuilder::WireIDsIntersect(const geo::WireID& wireID0, const geo::WireID& wireID1, geo::WireIDIntersection& widIntersection) const
+{
     bool success(false);
 
     // Do quick check that things are in the same logical TPC
-    if (wireID0.Cryostat != wireID1.Cryostat || wireID0.TPC != wireID1.TPC ||
-        wireID0.Plane == wireID1.Plane)
-      return success;
-
+    if (wireID0.Cryostat != wireID1.Cryostat || wireID0.TPC != wireID1.TPC || wireID0.Plane == wireID1.Plane) return success;
+        
     // Recover wire geometry information for each wire
-    const geo::WireGeo& wireGeo0 = m_wireReadoutGeom->Wire(wireID0);
-    const geo::WireGeo& wireGeo1 = m_wireReadoutGeom->Wire(wireID1);
+    const geo::WireGeo& wireGeo0 = m_wireReadoutAlg->Wire(wireID0);
+    const geo::WireGeo& wireGeo1 = m_wireReadoutAlg->Wire(wireID1);
 
     // Get wire position and direction for first wire
     auto wirePosArr = wireGeo0.GetCenter();
 
-    Eigen::Vector3f wirePos0(wirePosArr.X(), wirePosArr.Y(), wirePosArr.Z());
-    Eigen::Vector3f wireDir0(
-      wireGeo0.Direction().X(), wireGeo0.Direction().Y(), wireGeo0.Direction().Z());
+    Eigen::Vector3f wirePos0(wirePosArr.X(),wirePosArr.Y(),wirePosArr.Z());
+    Eigen::Vector3f wireDir0(wireGeo0.Direction().X(),wireGeo0.Direction().Y(),wireGeo0.Direction().Z());
+
+    //*********************************
+    // Kludge
+//    if (wireID0.Plane > 0) wireDir0[2] = -wireDir0[2];
 
     // And now the second one
     wirePosArr = wireGeo1.GetCenter();
 
-    Eigen::Vector3f wirePos1(wirePosArr.X(), wirePosArr.Y(), wirePosArr.Z());
-    Eigen::Vector3f wireDir1(
-      wireGeo1.Direction().X(), wireGeo1.Direction().Y(), wireGeo1.Direction().Z());
+    Eigen::Vector3f wirePos1(wirePosArr.X(),wirePosArr.Y(),wirePosArr.Z());
+    Eigen::Vector3f wireDir1(wireGeo1.Direction().X(),wireGeo1.Direction().Y(),wireGeo1.Direction().Z());
+
+    //**********************************
+    // Kludge
+//    if (wireID1.Plane > 0) wireDir1[2] = -wireDir1[2];
 
     // Get the distance of closest approach
     float arcLen0;
     float arcLen1;
 
-    if (closestApproach(wirePos0, wireDir0, wirePos1, wireDir1, arcLen0, arcLen1)) {
-      // Now check that arc lengths are within range
-      if (std::abs(arcLen0) < wireGeo0.HalfL() && std::abs(arcLen1) < wireGeo1.HalfL()) {
-        Eigen::Vector3f poca0 = wirePos0 + arcLen0 * wireDir0;
+    if (closestApproach(wirePos0, wireDir0, wirePos1, wireDir1, arcLen0, arcLen1))
+    {
+        // Now check that arc lengths are within range
+        if (std::abs(arcLen0) < wireGeo0.HalfL() && std::abs(arcLen1) < wireGeo1.HalfL())
+        {
+            Eigen::Vector3f poca0 = wirePos0 + arcLen0 * wireDir0;
 
-        widIntersection.y = poca0[1];
-        widIntersection.z = poca0[2];
+            widIntersection.y = poca0[1];
+            widIntersection.z = poca0[2];
 
-        success = true;
-      }
+            success = true;
+        }
     }
 
     return success;
-  }
+}
 
-  float SnippetHit3DBuilder::closestApproach(const Eigen::Vector3f& P0,
-                                             const Eigen::Vector3f& u0,
-                                             const Eigen::Vector3f& P1,
-                                             const Eigen::Vector3f& u1,
-                                             float& arcLen0,
-                                             float& arcLen1) const
-  {
+float SnippetHit3DBuilder::closestApproach(const Eigen::Vector3f& P0,
+                                                 const Eigen::Vector3f& u0,
+                                                 const Eigen::Vector3f& P1,
+                                                 const Eigen::Vector3f& u1,
+                                                 float&                 arcLen0,
+                                                 float&                 arcLen1) const
+{
     // Technique is to compute the arclength to each point of closest approach
     Eigen::Vector3f w0 = P0 - P1;
     float a(1.);
@@ -1324,102 +1545,28 @@ namespace lar_cluster3d {
     Eigen::Vector3f poca1 = P1 + arcLen1 * u1;
 
     return (poca0 - poca1).norm();
-  }
+}
 
-  float SnippetHit3DBuilder::chargeIntegral(float peakMean,
-                                            float peakAmp,
-                                            float peakSigma,
-                                            int low,
-                                            int hi) const
-  {
+float SnippetHit3DBuilder::chargeIntegral(float peakMean,
+                                           float peakAmp,
+                                           float peakSigma,
+                                           float areaNorm,
+                                           int   low,
+                                           int   hi) const
+{
     float integral(0);
 
-    for (int sigPos = low; sigPos < hi; sigPos++) {
-      float arg = (float(sigPos) - peakMean + 0.5) / peakSigma;
-      integral += peakAmp * std::exp(-0.5 * arg * arg);
+    for(int sigPos = low; sigPos < hi; sigPos++)
+    {
+        float arg = (float(sigPos) - peakMean + 0.5) / peakSigma;
+        integral += peakAmp * std::exp(-0.5 * arg * arg);
     }
 
     return integral;
-  }
+}
 
-  bool SnippetHit3DBuilder::makeDeadChannelPair(reco::ClusterHit3D& pairOut,
-                                                const reco::ClusterHit3D& pair,
-                                                size_t maxChanStatus,
-                                                size_t minChanStatus) const
-  {
-    // Assume failure (most common result)
-    bool result(false);
-
-    const reco::ClusterHit2D* hit0 = pair.getHits()[0];
-    const reco::ClusterHit2D* hit1 = pair.getHits()[1];
-
-    size_t missPlane(2);
-
-    // u plane hit is missing
-    if (!hit0) {
-      hit0 = pair.getHits()[2];
-      missPlane = 0;
-    }
-    // v plane hit is missing
-    else if (!hit1) {
-      hit1 = pair.getHits()[2];
-      missPlane = 1;
-    }
-
-    // Which plane is missing?
-    geo::WireID wireID0 = hit0->WireID();
-    geo::WireID wireID1 = hit1->WireID();
-
-    // Ok, recover the wireID expected in the third plane...
-    geo::WireID wireIn(wireID0.Cryostat, wireID0.TPC, missPlane, 0);
-    geo::WireID wireID = NearestWireID(pair.getPosition(), wireIn);
-
-    // There can be a round off issue so check the next wire as well
-    bool wireStatus = m_channelStatus[wireID.Plane][wireID.Wire] < maxChanStatus &&
-                      m_channelStatus[wireID.Plane][wireID.Wire] >= minChanStatus;
-    bool wireOneStatus = m_channelStatus[wireID.Plane][wireID.Wire + 1] < maxChanStatus &&
-                         m_channelStatus[wireID.Plane][wireID.Wire + 1] >= minChanStatus;
-
-    // Make sure they are of at least the minimum status
-    if (wireStatus || wireOneStatus) {
-      // Sort out which is the wire we're dealing with
-      if (!wireStatus) wireID.Wire += 1;
-
-      // Want to refine position since we "know" the missing wire
-      if (auto widIntersect0 = m_wireReadoutGeom->WireIDsIntersect(wireID0, wireID)) {
-        if (auto widIntersect1 = m_wireReadoutGeom->WireIDsIntersect(wireID1, wireID)) {
-          Eigen::Vector3f newPosition(
-            pair.getPosition()[0], pair.getPosition()[1], pair.getPosition()[2]);
-
-          newPosition[1] = (newPosition[1] + widIntersect0->y + widIntersect1->y) / 3.;
-          newPosition[2] =
-            (newPosition[2] + widIntersect0->z + widIntersect1->z - 2. * m_zPosOffset) / 3.;
-
-          pairOut = pair;
-          pairOut.setWireID(wireID);
-          pairOut.setPosition(newPosition);
-
-          if (hit0->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET)
-            hit0->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
-          if (hit1->getStatusBits() & reco::ClusterHit2D::USEDINTRIPLET)
-            hit1->setStatusBit(reco::ClusterHit2D::SHAREDINTRIPLET);
-
-          hit0->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
-          hit1->setStatusBit(reco::ClusterHit2D::USEDINTRIPLET);
-
-          result = true;
-        }
-      }
-    }
-
-    return result;
-  }
-
-  const reco::ClusterHit2D* SnippetHit3DBuilder::FindBestMatchingHit(
-    const Hit2DSet& hit2DSet,
-    const reco::ClusterHit3D& pair,
-    float pairDeltaTimeLimits) const
-  {
+const reco::ClusterHit2D* SnippetHit3DBuilder::FindBestMatchingHit(const Hit2DSet& hit2DSet, const reco::ClusterHit3D& pair, float pairDeltaTimeLimits) const
+{
     static const float minCharge(0.);
 
     const reco::ClusterHit2D* bestVHit(0);
@@ -1427,135 +1574,136 @@ namespace lar_cluster3d {
     float pairAvePeakTime(pair.getAvePeakTime());
 
     // Idea is to loop through the input set of hits and look for the best combination
-    for (const auto& hit2D : hit2DSet) {
-      if (hit2D->getHit()->Integral() < minCharge) continue;
+    for (const auto& hit2D : hit2DSet)
+    {
+        if (hit2D->getHit()->Integral() < minCharge) continue;
 
-      float hitVPeakTime(hit2D->getTimeTicks());
-      float deltaPeakTime(pairAvePeakTime - hitVPeakTime);
+        float hitVPeakTime(hit2D->getTimeTicks());
+        float deltaPeakTime(pairAvePeakTime-hitVPeakTime);
 
-      if (deltaPeakTime > pairDeltaTimeLimits) continue;
+        if (deltaPeakTime >  pairDeltaTimeLimits) continue;
 
-      if (deltaPeakTime < -pairDeltaTimeLimits) break;
+        if (deltaPeakTime < -pairDeltaTimeLimits) break;
 
-      pairDeltaTimeLimits = fabs(deltaPeakTime);
-      bestVHit = hit2D;
+        pairDeltaTimeLimits = fabs(deltaPeakTime);
+        bestVHit            = hit2D;
     }
 
     return bestVHit;
-  }
+}
 
-  int SnippetHit3DBuilder::FindNumberInRange(const Hit2DSet& hit2DSet,
-                                             const reco::ClusterHit3D& pair,
-                                             float range) const
-  {
+int SnippetHit3DBuilder::FindNumberInRange(const Hit2DSet& hit2DSet, const reco::ClusterHit3D& pair, float range) const
+{
     static const float minCharge(0.);
 
-    int numberInRange(0);
+    int    numberInRange(0);
     float pairAvePeakTime(pair.getAvePeakTime());
 
     // Idea is to loop through the input set of hits and look for the best combination
-    for (const auto& hit2D : hit2DSet) {
-      if (hit2D->getHit()->Integral() < minCharge) continue;
+    for (const auto& hit2D : hit2DSet)
+    {
+        if (hit2D->getHit()->Integral() < minCharge) continue;
 
-      float hitVPeakTime(hit2D->getTimeTicks());
-      float deltaPeakTime(pairAvePeakTime - hitVPeakTime);
+        float hitVPeakTime(hit2D->getTimeTicks());
+        float deltaPeakTime(pairAvePeakTime-hitVPeakTime);
 
-      if (deltaPeakTime > range) continue;
+        if (deltaPeakTime >  range) continue;
 
-      if (deltaPeakTime < -range) break;
+        if (deltaPeakTime < -range) break;
 
-      numberInRange++;
+        numberInRange++;
     }
 
     return numberInRange;
-  }
+}
 
-  geo::WireID SnippetHit3DBuilder::NearestWireID(const Eigen::Vector3f& position,
-                                                 const geo::WireID& wireIDIn) const
-  {
-    geo::WireID wireID = wireIDIn;
+geo::WireID SnippetHit3DBuilder::NearestWireID(const Eigen::Vector3f& position, const geo::WireID& wireIDIn) const
+{
+    int wire(0);
 
     // Embed the call to the geometry's services nearest wire id method in a try-catch block
-    try {
-      // Switch from NearestWireID to this method to avoid the roundoff error issues...
-      double distanceToWire =
-        m_wireReadoutGeom->Plane(wireIDIn).WireCoordinate(geo::vect::toPoint(position.data()));
-
-      wireID.Wire = int(distanceToWire);
+    try
+    {
+        // Not sure the thinking above but is wrong... switch back to NearestWireID...
+        wire = (m_wireReadoutAlg->NearestWireID(geo::vect::toPoint(position.data()),wireIDIn)).Wire;
     }
-    catch (std::exception& exc) {
-      // This can happen, almost always because the coordinates are **just** out of range
-      mf::LogWarning("Cluster3D") << "Exception caught finding nearest wire, position - "
-                                  << exc.what() << std::endl;
+    catch(std::exception& exc) 
+    {
+        // This can happen, almost always because the coordinates are **just** out of range
+        mf::LogDebug("Cluster3D") << "Exception caught finding nearest wire, position - " << exc.what() << std::endl;
 
-      // Assume extremum for wire number depending on z coordinate
-      if (position[2] < 0.5 * m_geometry->TPC().Length())
-        wireID.Wire = 0;
-      else
-        wireID.Wire = m_wireReadoutGeom->Nwires(wireIDIn.asPlaneID()) - 1;
+        // Assume extremum for wire number depending on z coordinate
+        if (position[2] < m_geometry->TPC({0,0}).ActiveLength()*0.5) wire = 0;
+        else                                              wire = m_wireReadoutAlg->Nwires(wireIDIn.asPlaneID()) - 1;
     }
+
+    geo::WireID wireID(wireIDIn.Cryostat,wireIDIn.TPC,wireIDIn.Plane,wire);
 
     return wireID;
-  }
+}
 
-  float SnippetHit3DBuilder::DistanceFromPointToHitWire(const Eigen::Vector3f& position,
-                                                        const geo::WireID& wireIDIn) const
-  {
+float SnippetHit3DBuilder::DistanceFromPointToHitWire(const Eigen::Vector3f& position, const geo::WireID& wireIDIn) const
+{
     float distance = std::numeric_limits<float>::max();
 
     // Embed the call to the geometry's services nearest wire id method in a try-catch block
-    try {
-      // Recover wire geometry information for each wire
-      const geo::WireGeo& wireGeo = m_wireReadoutGeom->Wire(wireIDIn);
+    try
+    {
+        // Recover wire geometry information for each wire
+        const geo::WireGeo& wireGeo = m_wireReadoutAlg->Wire(wireIDIn);
 
-      // Get wire position and direction for first wire
-      auto const wirePosArr = wireGeo.GetCenter();
+        // Get wire position and direction for first wire
+        auto const wirePosArr = wireGeo.GetCenter();
 
-      Eigen::Vector3f wirePos(wirePosArr.X(), wirePosArr.Y(), wirePosArr.Z());
-      Eigen::Vector3f wireDir(
-        wireGeo.Direction().X(), wireGeo.Direction().Y(), wireGeo.Direction().Z());
+        Eigen::Vector3f wirePos(wirePosArr.X(),wirePosArr.Y(),wirePosArr.Z());
+        Eigen::Vector3f wireDir(wireGeo.Direction().X(),wireGeo.Direction().Y(),wireGeo.Direction().Z());
 
-      // Want the hit position to have same x value as wire coordinates
-      Eigen::Vector3f hitPosition(wirePos[0], position[1], position[2]);
+        //*********************************
+        // Kludge
+//        if (wireIDIn.Plane > 0) wireDir[2] = -wireDir[2];
 
-      // Get arc length to doca
-      double arcLen = (hitPosition - wirePos).dot(wireDir);
 
-      // Make sure arclen is in range
-      if (abs(arcLen) < wireGeo.HalfL()) {
-        Eigen::Vector3f docaVec = hitPosition - (wirePos + arcLen * wireDir);
+        // Want the hit position to have same x value as wire coordinates
+        Eigen::Vector3f hitPosition(wirePos[0],position[1],position[2]);
 
-        distance = docaVec.norm();
-      }
+        // Get arc length to doca
+        double arcLen = (hitPosition - wirePos).dot(wireDir);
+
+        // Make sure arclen is in range
+        if (abs(arcLen) < wireGeo.HalfL())
+        {
+            Eigen::Vector3f docaVec = hitPosition - (wirePos + arcLen * wireDir);
+
+            distance = docaVec.norm();
+        }
     }
-    catch (std::exception& exc) {
-      // This can happen, almost always because the coordinates are **just** out of range
-      mf::LogWarning("Cluster3D") << "Exception caught finding nearest wire, position - "
-                                  << exc.what() << std::endl;
+    catch(std::exception& exc)
+    {
+        // This can happen, almost always because the coordinates are **just** out of range
+        mf::LogWarning("Cluster3D") << "Exception caught finding nearest wire, position - " << exc.what() << std::endl;
 
-      // Assume extremum for wire number depending on z coordinate
-      distance = 0.;
+        // Assume extremum for wire number depending on z coordinate
+        distance = 0.;
     }
 
     return distance;
-  }
+}
 
-  //------------------------------------------------------------------------------------------------------------------------------------------
-  bool SetHitTimeOrder(const reco::ClusterHit2D* left, const reco::ClusterHit2D* right)
-  {
+//------------------------------------------------------------------------------------------------------------------------------------------
+bool SetHitTimeOrder(const reco::ClusterHit2D* left, const reco::ClusterHit2D* right)
+{
     // Sort by "modified start time" of pulse
     return left->getHit()->PeakTime() < right->getHit()->PeakTime();
-  }
+}
 
-  bool Hit2DSetCompare::operator()(const reco::ClusterHit2D* left,
-                                   const reco::ClusterHit2D* right) const
-  {
+bool Hit2DSetCompare::operator() (const reco::ClusterHit2D* left, const reco::ClusterHit2D* right) const
+{
     return left->getHit()->PeakTime() < right->getHit()->PeakTime();
-  }
+}
 
-  //------------------------------------------------------------------------------------------------------------------------------------------
-  void SnippetHit3DBuilder::CollectArtHits(const art::Event& evt) const
-  {
+//------------------------------------------------------------------------------------------------------------------------------------------
+void SnippetHit3DBuilder::CollectArtHits(const art::Event& evt) const
+{
     /**
      *  @brief Recover the 2D hits from art and fill out the local data structures for the 3D clustering
      */
@@ -1565,16 +1713,16 @@ namespace lar_cluster3d {
     std::vector<const recob::Hit*> recobHitVec;
 
     // Loop through the list of input sources
-    for (const auto& inputTag : m_hitFinderTagVec) {
-      art::Handle<std::vector<recob::Hit>> recobHitHandle;
-      evt.getByLabel(inputTag, recobHitHandle);
+    for(const auto& inputTag : m_hitFinderTagVec)
+    {
+        art::Handle< std::vector<recob::Hit> > recobHitHandle;
+        evt.getByLabel(inputTag, recobHitHandle);
 
-      if (!recobHitHandle.isValid() || recobHitHandle->size() == 0) continue;
+        if (!recobHitHandle.isValid() || recobHitHandle->size() == 0) continue;
 
-      recobHitVec.reserve(recobHitVec.size() + recobHitHandle->size());
+        recobHitVec.reserve(recobHitVec.size() + recobHitHandle->size());
 
-      for (const auto& hit : *recobHitHandle)
-        recobHitVec.push_back(&hit);
+        for(const auto& hit : *recobHitHandle) recobHitVec.push_back(&hit);
     }
 
     // If the vector is empty there is nothing to do
@@ -1584,128 +1732,122 @@ namespace lar_cluster3d {
 
     if (m_enableMonitoring) theClockMakeHits.start();
 
-    // We'll want to correct the hit times for the plane offsets
-    // (note this is already taken care of when converting to position)
-    std::map<geo::PlaneID, double> planeOffsetMap;
-
     // Need the detector properties which needs the clocks
-    auto const clock_data =
-      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
-    auto const det_prop =
-      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clock_data);
+    auto const clock_data = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+    auto const det_prop   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clock_data);
 
     // Try to output a formatted string
     std::string debugMessage("");
 
+    // Keep track of x position limits
+    std::map<geo::PlaneID,double> planeIDToPositionMap;
+
     // Initialize the plane to hit vector map
-    for (size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++) {
-      for (size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++) {
-        m_planeToSnippetHitMap[geo::PlaneID(cryoIdx, tpcIdx, 0)] = SnippetHitMap();
-        m_planeToSnippetHitMap[geo::PlaneID(cryoIdx, tpcIdx, 1)] = SnippetHitMap();
-        m_planeToSnippetHitMap[geo::PlaneID(cryoIdx, tpcIdx, 2)] = SnippetHitMap();
+    for(size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++)
+    {
+        for(size_t tpcIdx = 0; tpcIdx < m_geometry->NTPC(); tpcIdx++)
+        {
+            m_planeToSnippetHitMap[geo::PlaneID(cryoIdx,tpcIdx,0)] = SnippetHitMap();
+            m_planeToSnippetHitMap[geo::PlaneID(cryoIdx,tpcIdx,1)] = SnippetHitMap();
+            m_planeToSnippetHitMap[geo::PlaneID(cryoIdx,tpcIdx,2)] = SnippetHitMap();
 
-        // What we want here are the relative offsets between the planes
-        // Note that plane 0 is assumed the "first" plane and is the reference
-        planeOffsetMap[geo::PlaneID(cryoIdx, tpcIdx, 0)] = 0.;
-        planeOffsetMap[geo::PlaneID(cryoIdx, tpcIdx, 1)] =
-          det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 1)) -
-          det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 0));
-        planeOffsetMap[geo::PlaneID(cryoIdx, tpcIdx, 2)] =
-          det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 2)) -
-          det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 0));
+            // Should we provide output?
+            if (!m_weHaveAllBeenHereBefore)
+            {
+                std::ostringstream outputString;
 
-        // Should we provide output?
-        if (!m_weHaveAllBeenHereBefore) {
-          std::ostringstream outputString;
+                outputString << "***> plane 0 offset: " << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx,tpcIdx,0))->second
+                             << ", plane 1: " << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx,tpcIdx,1))->second
+                             << ", plane    2: " << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx,tpcIdx,2))->second << "\n";
+                outputString << "     Det prop plane 0: " << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,0)) << ", plane 1: "  << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,1)) << ", plane 2: " << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,2)) << ", Trig: " << trigger_offset(clock_data) << "\n";
+                debugMessage += outputString.str() + "\n";
+            }
 
-          outputString << "***> plane 0 offset: "
-                       << planeOffsetMap[geo::PlaneID(cryoIdx, tpcIdx, 0)]
-                       << ", plane 1: " << planeOffsetMap[geo::PlaneID(cryoIdx, tpcIdx, 1)]
-                       << ", plane    2: " << planeOffsetMap[geo::PlaneID(cryoIdx, tpcIdx, 2)]
-                       << "\n";
-          debugMessage += outputString.str();
-          outputString << "     Det prop plane 0: "
-                       << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 0))
-                       << ", plane 1: "
-                       << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 1))
-                       << ", plane 2: "
-                       << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx, tpcIdx, 2))
-                       << ", Trig: " << trigger_offset(clock_data) << "\n";
-          debugMessage += outputString.str();
+            double xPosition(det_prop.ConvertTicksToX(0., 2, tpcIdx, cryoIdx));
+
+            planeIDToPositionMap[geo::PlaneID(cryoIdx,tpcIdx,2)] = xPosition;
         }
-      }
     }
 
-    if (!m_weHaveAllBeenHereBefore) {
-      mf::LogDebug("Cluster3D") << debugMessage << std::endl;
+    if (!m_weHaveAllBeenHereBefore)
+    {
+        for(const auto& planeToPositionPair : planeIDToPositionMap)
+        {
+            std::ostringstream outputString;
 
-      std::cout << debugMessage << std::endl;
+            outputString << "***> Plane " << planeToPositionPair.first << " has time=0 position: " << planeToPositionPair.second << "\n";
 
-      m_weHaveAllBeenHereBefore = true;
+            debugMessage += outputString.str();
+        }
+
+        mf::LogDebug("SnippetHit3D") << debugMessage << std::endl;
+
+        m_weHaveAllBeenHereBefore = true;
     }
 
     // Cycle through the recob hits to build ClusterHit2D objects and insert
     // them into the map
-    for (const auto& recobHit : recobHitVec) {
-      // Reject hits with negative charge, these are misreconstructed
-      if (recobHit->Integral() < 0.) continue;
+    for (const auto& recobHit : recobHitVec)
+    {
+        // Reject hits with negative charge, these are misreconstructed
+        if (recobHit->Integral() < 0.) continue;
 
-      // For some detectors we can have multiple wire ID's associated to a given channel.
-      // So we recover the list of these wire IDs
-      const std::vector<geo::WireID>& wireIDs =
-        m_wireReadoutGeom->ChannelToWire(recobHit->Channel());
+        // For some detectors we can have multiple wire ID's associated to a given channel.
+        // So we recover the list of these wire IDs
+        const std::vector<geo::WireID>& wireIDs = m_wireReadoutAlg->ChannelToWire(recobHit->Channel());
 
-      // Start/End ticks to identify the snippet
-      HitStartEndPair hitStartEndPair(recobHit->StartTick(), recobHit->EndTick());
+        // Start/End ticks to identify the snippet
+        HitStartEndPair hitStartEndPair(recobHit->StartTick(),recobHit->EndTick());
 
-      // Can this really happen?
-      if (hitStartEndPair.second <= hitStartEndPair.first) {
-        std::cout << "Yes, found a hit with end time less than start time: "
-                  << hitStartEndPair.first << "/" << hitStartEndPair.second
-                  << ", mult: " << recobHit->Multiplicity() << std::endl;
-        continue;
-      }
+        // Can this really happen?
+        if (hitStartEndPair.second <= hitStartEndPair.first)
+        {
+            mf::LogDebug("SnippetHit3D") << "Yes, found a hit with end time less than start time: " << hitStartEndPair.first << "/" << hitStartEndPair.second << ", mult: " << recobHit->Multiplicity();
+            continue;
+        }
 
-      // And then loop over all possible to build out our maps
-      for (auto wireID : wireIDs) {
-        // Check if this is an invalid TPC
-        // (for example, in protoDUNE there are logical TPC's which see no signal)
-        if (std::find(m_invalidTPCVec.begin(), m_invalidTPCVec.end(), wireID.TPC) !=
-            m_invalidTPCVec.end())
-          continue;
+        // And then loop over all possible to build out our maps
+        //for(const auto& wireID : wireIDs)
+        for(auto wireID : wireIDs)
+        {
+            // Check if this is an invalid TPC
+            // (for example, in protoDUNE there are logical TPC's which see no signal)
+            if (std::find(m_invalidTPCVec.begin(),m_invalidTPCVec.end(),wireID.TPC) != m_invalidTPCVec.end()) continue;
 
-        // Note that a plane ID will define cryostat, TPC and plane
-        const geo::PlaneID& planeID = wireID.planeID();
+            // Note that a plane ID will define cryostat, TPC and plane
+            const geo::PlaneID& planeID = wireID.planeID();
 
-        double hitPeakTime(recobHit->PeakTime() - planeOffsetMap[planeID]);
-        double xPosition(det_prop.ConvertTicksToX(
-          recobHit->PeakTime(), planeID.Plane, planeID.TPC, planeID.Cryostat));
+            double hitPeakTime(recobHit->PeakTime() - m_PlaneToT0OffsetMap.find(planeID)->second);
+            double xPosition(det_prop.ConvertTicksToX(recobHit->PeakTime(), planeID.Plane, planeID.TPC, planeID.Cryostat));
 
-        m_clusterHit2DMasterList.emplace_back(0, 0., 0., xPosition, hitPeakTime, wireID, recobHit);
+            m_clusterHit2DMasterList.emplace_back(0, 0., 0., xPosition, hitPeakTime, wireID, recobHit);
 
-        m_planeToSnippetHitMap[planeID][hitStartEndPair].emplace_back(
-          &m_clusterHit2DMasterList.back());
-        m_planeToWireToHitSetMap[planeID][wireID.Wire].insert(&m_clusterHit2DMasterList.back());
-      }
+            m_planeToSnippetHitMap[planeID][hitStartEndPair].emplace_back(&m_clusterHit2DMasterList.back());
+            m_planeToWireToHitSetMap[planeID][wireID.Wire].insert(&m_clusterHit2DMasterList.back());
+        }
     }
 
-    if (m_enableMonitoring) {
-      theClockMakeHits.stop();
+    // Make a loop through to sort the recover hits in time order
+//    for(auto& hitVectorMap : m_planeToSnippetHitMap)
+//        std::sort(hitVectorMap.second.begin(), hitVectorMap.second.end(), SetHitTimeOrder);
 
-      m_timeVector[COLLECTARTHITS] = theClockMakeHits.accumulated_real_time();
+    if (m_enableMonitoring)
+    {
+        theClockMakeHits.stop();
+
+        m_timeVector[COLLECTARTHITS] = theClockMakeHits.accumulated_real_time();
     }
 
-    mf::LogDebug("Cluster3D") << ">>>>> Number of ART hits: " << m_clusterHit2DMasterList.size()
-                              << std::endl;
-  }
+    mf::LogDebug("SnippetHit3D") << ">>>>> Number of ART hits: " << m_clusterHit2DMasterList.size() << std::endl;
+}
 
-  //------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
 
-  void SnippetHit3DBuilder::CreateNewRecobHitCollection(art::Event& event,
-                                                        reco::HitPairList& hitPairList,
-                                                        std::vector<recob::Hit>& hitPtrVec,
-                                                        RecobHitToPtrMap& recobHitToPtrMap)
-  {
+void SnippetHit3DBuilder::CreateNewRecobHitCollection(art::Event&              event,
+                                                            reco::HitPairList&       hitPairList,
+                                                            std::vector<recob::Hit>& hitPtrVec,
+                                                            RecobHitToPtrMap&        recobHitToPtrMap)
+{
     // Set up the timing
     cet::cpu_timer theClockBuildNewHits;
 
@@ -1724,51 +1866,53 @@ namespace lar_cluster3d {
     hitPtrVec.reserve(m_clusterHit2DMasterList.size());
 
     // Scheme is to loop through all 3D hits, then through each associated ClusterHit2D object
-    for (reco::ClusterHit3D& hit3D : hitPairList) {
-      reco::ClusterHit2DVec& hit2DVec = hit3D.getHits();
+    for(reco::ClusterHit3D& hit3D : hitPairList)
+    {
+        reco::ClusterHit2DVec& hit2DVec = hit3D.getHits();
 
-      // The loop is over the index so we can recover the correct WireID to associate to the new hit when made
-      for (size_t idx = 0; idx < hit3D.getHits().size(); idx++) {
-        const reco::ClusterHit2D* hit2D = hit2DVec[idx];
+        // The loop is over the index so we can recover the correct WireID to associate to the new hit when made
+        for(size_t idx = 0; idx < hit3D.getHits().size(); idx++)
+        {
+            const reco::ClusterHit2D* hit2D = hit2DVec[idx];
 
-        // Have we seen this 2D hit already?
-        if (visitedHit2DSet.find(hit2D) == visitedHit2DSet.end()) {
-          visitedHit2DSet.insert(hit2D);
+            if (!hit2D) continue;
 
-          // Create and save the new recob::Hit with the correct WireID
-          hitPtrVec.emplace_back(
-            recob::HitCreator(*hit2D->getHit(), hit3D.getWireIDs()[idx]).copy());
+            // Have we seen this 2D hit already?
+            if (visitedHit2DSet.find(hit2D) == visitedHit2DSet.end())
+            {
+                visitedHit2DSet.insert(hit2D);
 
-          // Recover a pointer to it...
-          recob::Hit* newHit = &hitPtrVec.back();
+                // Create and save the new recob::Hit with the correct WireID
+                hitPtrVec.emplace_back(recob::HitCreator(*hit2D->getHit(), hit3D.getWireIDs()[idx]).copy());
 
-          // Create a mapping from this hit to an art Ptr representing it
-          recobHitToPtrMap[newHit] = ptrMaker(hitPtrVec.size() - 1);
+                // Recover a pointer to it...
+                recob::Hit* newHit = &hitPtrVec.back();
 
-          // And set the pointer to this hit in the ClusterHit2D object
-          const_cast<reco::ClusterHit2D*>(hit2D)->setHit(newHit);
+                // Create a mapping from this hit to an art Ptr representing it
+                recobHitToPtrMap[newHit] = ptrMaker(hitPtrVec.size()-1);
+
+                // And set the pointer to this hit in the ClusterHit2D object
+                const_cast<reco::ClusterHit2D*>(hit2D)->setHit(newHit);
+            }
         }
-      }
     }
 
     size_t numNewHits = hitPtrVec.size();
 
-    if (m_enableMonitoring) {
-      theClockBuildNewHits.stop();
+    if (m_enableMonitoring)
+    {
+        theClockBuildNewHits.stop();
 
-      m_timeVector[BUILDNEWHITS] = theClockBuildNewHits.accumulated_real_time();
+        m_timeVector[BUILDNEWHITS] = theClockBuildNewHits.accumulated_real_time();
     }
 
-    mf::LogDebug("Cluster3D") << ">>>>> New output recob::Hit size: " << numNewHits << " (vs "
-                              << m_clusterHit2DMasterList.size() << " input)" << std::endl;
+    mf::LogDebug("SnippetHit3D") << ">>>>> New output recob::Hit size: " << numNewHits << " (vs " << m_clusterHit2DMasterList.size() << " input)" << std::endl;
 
     return;
-  }
+}
 
-  void SnippetHit3DBuilder::makeWireAssns(const art::Event& evt,
-                                          art::Assns<recob::Wire, recob::Hit>& wireAssns,
-                                          RecobHitToPtrMap& recobHitPtrMap) const
-  {
+void SnippetHit3DBuilder::makeWireAssns(const art::Event& evt, art::Assns<recob::Wire, recob::Hit>& wireAssns, RecobHitToPtrMap& recobHitPtrMap) const
+{
     // Let's make sure the input associations container is empty
     wireAssns = art::Assns<recob::Wire, recob::Hit>();
 
@@ -1777,38 +1921,44 @@ namespace lar_cluster3d {
     std::unordered_map<raw::ChannelID_t, art::Ptr<recob::Wire>> channelToWireMap;
 
     // Go through the list of input sources and fill out the map
-    for (const auto& inputTag : m_hitFinderTagVec) {
-      art::ValidHandle<std::vector<recob::Hit>> hitHandle =
-        evt.getValidHandle<std::vector<recob::Hit>>(inputTag);
+    for(const auto& inputTag : m_hitFinderTagVec)
+    {
+        art::ValidHandle<std::vector<recob::Hit>> hitHandle = evt.getValidHandle<std::vector<recob::Hit>>(inputTag);
 
-      art::FindOneP<recob::Wire> hitToWireAssns(hitHandle, evt, inputTag);
+        art::FindOneP<recob::Wire> hitToWireAssns(hitHandle, evt, inputTag);
 
-      if (hitToWireAssns.isValid()) {
-        for (size_t wireIdx = 0; wireIdx < hitToWireAssns.size(); wireIdx++) {
-          art::Ptr<recob::Wire> wire = hitToWireAssns.at(wireIdx);
+        if (hitToWireAssns.isValid())
+        {
+            for(size_t wireIdx = 0; wireIdx < hitToWireAssns.size(); wireIdx++)
+            {
+                art::Ptr<recob::Wire> wire = hitToWireAssns.at(wireIdx);
 
-          channelToWireMap[wire->Channel()] = wire;
+                channelToWireMap[wire->Channel()] = wire;
+            }
         }
-      }
     }
 
     // Now fill the container
-    for (const auto& hitPtrPair : recobHitPtrMap) {
-      raw::ChannelID_t channel = hitPtrPair.first->Channel();
+    for(const auto& hitPtrPair : recobHitPtrMap)
+    {
+        raw::ChannelID_t channel = hitPtrPair.first->Channel();
 
-      std::unordered_map<raw::ChannelID_t, art::Ptr<recob::Wire>>::iterator chanWireItr =
-        channelToWireMap.find(channel);
+        std::unordered_map<raw::ChannelID_t, art::Ptr<recob::Wire>>::iterator chanWireItr = channelToWireMap.find(channel);
 
-      if (!(chanWireItr != channelToWireMap.end())) { continue; }
+        if (!(chanWireItr != channelToWireMap.end()))
+        {
+            //mf::LogDebug("SnippetHit3D") << "** Did not find channel to wire match! Skipping..." << std::endl;
+            continue;
+        }
 
-      wireAssns.addSingle(chanWireItr->second, hitPtrPair.second);
+        wireAssns.addSingle(chanWireItr->second, hitPtrPair.second);
     }
-  }
 
-  void SnippetHit3DBuilder::makeRawDigitAssns(const art::Event& evt,
-                                              art::Assns<raw::RawDigit, recob::Hit>& rawDigitAssns,
-                                              RecobHitToPtrMap& recobHitPtrMap) const
-  {
+    return;
+}
+
+void SnippetHit3DBuilder::makeRawDigitAssns(const art::Event& evt, art::Assns<raw::RawDigit, recob::Hit>& rawDigitAssns, RecobHitToPtrMap& recobHitPtrMap) const
+{
     // Let's make sure the input associations container is empty
     rawDigitAssns = art::Assns<raw::RawDigit, recob::Hit>();
 
@@ -1817,35 +1967,43 @@ namespace lar_cluster3d {
     std::unordered_map<raw::ChannelID_t, art::Ptr<raw::RawDigit>> channelToRawDigitMap;
 
     // Go through the list of input sources and fill out the map
-    for (const auto& inputTag : m_hitFinderTagVec) {
-      art::ValidHandle<std::vector<recob::Hit>> hitHandle =
-        evt.getValidHandle<std::vector<recob::Hit>>(inputTag);
+    for(const auto& inputTag : m_hitFinderTagVec)
+    {
+        art::ValidHandle<std::vector<recob::Hit>> hitHandle = evt.getValidHandle<std::vector<recob::Hit>>(inputTag);
 
-      art::FindOneP<raw::RawDigit> hitToRawDigitAssns(hitHandle, evt, inputTag);
+        art::FindOneP<raw::RawDigit> hitToRawDigitAssns(hitHandle, evt, inputTag);
 
-      if (hitToRawDigitAssns.isValid()) {
-        for (size_t rawDigitIdx = 0; rawDigitIdx < hitToRawDigitAssns.size(); rawDigitIdx++) {
-          art::Ptr<raw::RawDigit> rawDigit = hitToRawDigitAssns.at(rawDigitIdx);
+        if (hitToRawDigitAssns.isValid())
+        {
+            for(size_t rawDigitIdx = 0; rawDigitIdx < hitToRawDigitAssns.size(); rawDigitIdx++)
+            {
+                art::Ptr<raw::RawDigit> rawDigit = hitToRawDigitAssns.at(rawDigitIdx);
 
-          channelToRawDigitMap[rawDigit->Channel()] = rawDigit;
+                channelToRawDigitMap[rawDigit->Channel()] = rawDigit;
+            }
         }
-      }
     }
 
     // Now fill the container
-    for (const auto& hitPtrPair : recobHitPtrMap) {
-      raw::ChannelID_t channel = hitPtrPair.first->Channel();
+    for(const auto& hitPtrPair : recobHitPtrMap)
+    {
+        raw::ChannelID_t channel = hitPtrPair.first->Channel();
 
-      std::unordered_map<raw::ChannelID_t, art::Ptr<raw::RawDigit>>::iterator chanRawDigitItr =
-        channelToRawDigitMap.find(channel);
+        std::unordered_map<raw::ChannelID_t, art::Ptr<raw::RawDigit>>::iterator chanRawDigitItr = channelToRawDigitMap.find(channel);
 
-      if (chanRawDigitItr == channelToRawDigitMap.end()) { continue; }
+        if (chanRawDigitItr == channelToRawDigitMap.end())
+        {
+            //mf::LogDebug("SnippetHit3D") << "** Did not find channel to wire match! Skipping..." << std::endl;
+           continue;
+        }
 
-      rawDigitAssns.addSingle(chanRawDigitItr->second, hitPtrPair.second);
+        rawDigitAssns.addSingle(chanRawDigitItr->second, hitPtrPair.second);
     }
-  }
 
-  //------------------------------------------------------------------------------------------------------------------------------------------
+    return;
+}
 
-  DEFINE_ART_CLASS_TOOL(SnippetHit3DBuilder)
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+DEFINE_ART_CLASS_TOOL(SnippetHit3DBuilder)
 } // namespace lar_cluster3d

--- a/larreco/RecoAlg/Cluster3DAlgs/cluster3dalgorithms.fcl
+++ b/larreco/RecoAlg/Cluster3DAlgs/cluster3dalgorithms.fcl
@@ -27,14 +27,23 @@ standard_snippethit3dbuilder:
 {
   tool_type:             SnippetHit3DBuilder
   HitFinderTagVec:       ["gaushit"]
-  EnableMonitoring:      true  # enable monitoring of functions
-  LongHitsStretchFactor: 1.0   # Allows to stretch long hits widths if desired
-  HitWidthScaleFactor:   3.0   #
-  PulseHeightFraction:   0.4
-  DeltaPeakTimeSig:      1.75  # "Significance" of agreement between 2 hit peak times
+  EnableMonitoring:      true    # enable monitoring of functions
+  HitWidthScaleFactor:   3.0     #
+  RangeNumSigma:         3.0     #
+  LongHitsStretchFactor: 1.5     # Allows to stretch long hits widths if desired
+  PulseHeightFraction:   0.4     # If multiple hits are under this fraction of the peak hit amplitude consider rejecting
+  PHLowSelection:        8.      # If matching the above then require hits larger than this
+  MinPHFor2HitPoints:    4.      # Don't consider hits less than this for 2 hit space points
+  DeltaPeakTimeSig:      1.75    # "Significance" of agreement between 2 hit peak times
+  ZPosOffset:            0.00
+  MaxHitChiSquare:       6.00
   WirePitchScaleFactor:  1.9
-  MaxHitChiSquare:       6.0
+  SaveBadChannelPairs:   true    # Create and save space points with one channel "bad"
+  SaveMythicalPoints:    true    # Create and save 2 hit combinations
+  MaxMythicalChiSquare:  25.     # Cut on 2 hit points
+  UseT0Offsets:          false
   OutputHistograms:      false
+  MakeAssociations:      false
 }
 
 standard_spacepointhit3dbuilder:


### PR DESCRIPTION
For various reasons the art tool used to make space points was copied to ICARUS for more development before using it to input space points to what is now the SPINE ML reconstruction. It was then copied to the SBN level code base so it could also be used at SBND. Now SPINE is integrating into the DUNE FD and ProtoDUNE so it makes sense to move the updated code back into the larreco repository. 

There are also some updates to the cluster3D module so it only runs the space point building, not the full set of pat rec tools it was originally developed to do. In the near future will replace this with a new module that only builds space points. 
