### PR TITLE
Restore guard comparing `HitSumStartItr`, `HitsumEndItr` to avoid segfaulting

### DIFF
--- a/larreco/HitFinder/GausHitFinder_module.cc
+++ b/larreco/HitFinder/GausHitFinder_module.cc
@@ -523,7 +523,6 @@ namespace hit {
 
                 //protection to avoid negative ranges
                 if (newright - newleft < 0) continue;
-		//if (HitsumStartItr > HitsumEndItr) continue;
 
                 //avoid ranges out of ROI if it happens
                 if (HitsumStartItr < sumStartItr) HitsumStartItr = sumStartItr;

--- a/larreco/HitFinder/GausHitFinder_module.cc
+++ b/larreco/HitFinder/GausHitFinder_module.cc
@@ -523,12 +523,14 @@ namespace hit {
 
                 //protection to avoid negative ranges
                 if (newright - newleft < 0) continue;
-                if (HitsumStartItr > HitsumEndItr) continue;
+		//if (HitsumStartItr > HitsumEndItr) continue;
 
                 //avoid ranges out of ROI if it happens
                 if (HitsumStartItr < sumStartItr) HitsumStartItr = sumStartItr;
 
                 if (HitsumEndItr > sumEndItr) HitsumEndItr = sumEndItr;
+
+		if (HitsumStartItr > HitsumEndItr) continue;
 
                 // ### Sum of ADC counts
                 double ROIsumADC = std::accumulate(sumStartItr, sumEndItr, 0.);

--- a/larreco/HitFinder/GausHitFinder_module.cc
+++ b/larreco/HitFinder/GausHitFinder_module.cc
@@ -529,7 +529,7 @@ namespace hit {
 
                 if (HitsumEndItr > sumEndItr) HitsumEndItr = sumEndItr;
 
-		if (HitsumStartItr > HitsumEndItr) continue;
+				if (HitsumStartItr > HitsumEndItr) continue;
 
                 // ### Sum of ADC counts
                 double ROIsumADC = std::accumulate(sumStartItr, sumEndItr, 0.);

--- a/larreco/HitFinder/GausHitFinder_module.cc
+++ b/larreco/HitFinder/GausHitFinder_module.cc
@@ -529,7 +529,7 @@ namespace hit {
 
                 if (HitsumEndItr > sumEndItr) HitsumEndItr = sumEndItr;
 
-				if (HitsumStartItr > HitsumEndItr) continue;
+                if (HitsumStartItr > HitsumEndItr) continue;
 
                 // ### Sum of ADC counts
                 double ROIsumADC = std::accumulate(sumStartItr, sumEndItr, 0.);


### PR DESCRIPTION
During SBND MC processing, a number of simulation jobs failed throwing a segfault that traced back to this line in `GausHitFinder_module.cc`, where the `HitsumStartItr` ended up pointing to an address that was ahead of the `HitsumEndItr`.

By looking at the code, this behaviour was intended to have caused a `continue` statement to fire, but because these iterators are modified after the original guard, edge cases where the iterators end up out of alignment can sneak by and cause segfaults.

This PR restores this guard by moving it after the `HitSum*Itr` iterators have been modified.