### PR TITLE
Fix the output of the "chisq" for two hit space points

### DIFF
--- a/larreco/ClusterFinder/Cluster3D_module.cc
+++ b/larreco/ClusterFinder/Cluster3D_module.cc
@@ -1158,10 +1158,7 @@ namespace lar_cluster3d {
       RecobHitVector recobHits;
 
       for (const auto hit : hitPair.getHits()) {
-        if (!hit) {
-          chisq = -1000.;
-          continue;
-        }
+        if (!hit) continue;
 
         art::Ptr<recob::Hit> hitPtr = hitToPtrMap[hit->getHit()];
         recobHits.push_back(hitPtr);


### PR DESCRIPTION
The space point "chisq" is important to the deghosting for the SPINE reconstruction but the module, when creating the space points, sets this to -1000 for two hit space points. Here we remove that overwrite of the chisq for this specific case. It has already been changed in the cloned versions of this module used by the SBN (and now DUNE FD) experiments, the idea is to fix here so all can use a single  module. 